### PR TITLE
feat: improve mobile editor layout

### DIFF
--- a/docs_dreamboard/project-idea.md
+++ b/docs_dreamboard/project-idea.md
@@ -15,7 +15,7 @@ The current app is a strong prototype, and the repository is now on a safer refa
 - the static app is deployed through Vercel-backed CI/CD
 - AI orchestration and review policy now follow the standard repository flow
 - the frontend has been split into HTML shell + external CSS/JS modules
-- editor responsiveness is improving, but the mobile experience still needs a dedicated product pass
+- the editor has entered a dedicated mobile adaptation phase with its own phone-first interaction model
 
 ## Infra Goal
 

--- a/docs_dreamboard/project/frontend/frontend-docs.md
+++ b/docs_dreamboard/project/frontend/frontend-docs.md
@@ -19,7 +19,16 @@ The editor now uses container-based canvas sizing instead of raw viewport math:
 - the editor shell owns the available space
 - the Fabric canvas resizes from the `.canvas-area` container
 - a `ResizeObserver` keeps the canvas in sync with footer height and viewport changes
-- the mobile sidebar remains an overlay, while the canvas keeps a safe top offset under the menu trigger
+- the mobile editor now uses a dedicated interaction shell instead of a desktop left rail squeezed into phone width
+
+## Mobile Editor Model
+
+The current static app now treats phone layouts as a separate editor mode:
+
+- a fixed mobile top bar keeps the primary entry points reachable
+- tool controls open as a bottom sheet instead of an off-canvas desktop sidebar
+- the canvas reserves safe space for the top bar and sticky footer
+- the object menu docks near the bottom of the canvas on mobile instead of chasing the selected object into cramped positions
 
 ## Build Contract
 
@@ -36,7 +45,7 @@ The recommended target architecture for the next phase is:
 - `Vite + React + TypeScript`
 - dedicated components for landing and editor shells
 - extracted locales, assets, and editor services
-- removal of remaining inline action handlers in favor of bound module listeners
-- a dedicated mobile editor interaction model instead of desktop controls squeezed into a phone viewport
+- extraction of the mobile editor shell into dedicated components instead of shared static DOM branches
+- stronger visual and interaction parity between landing and editor on small screens
 
 Until that migration happens, all changes should keep the static app functioning and deployable.

--- a/index.html
+++ b/index.html
@@ -112,15 +112,27 @@
 
     <!-- EDITOR VIEW -->
     <div class="editor-view" id="editorView">
-      <!-- Mobile menu button -->
-      <button
-        class="mobile-menu-btn"
-        id="mobileMenuBtn"
-        type="button"
-        aria-label="Menu"
-      >
-        ☰
-      </button>
+      <div class="editor-mobile-topbar">
+        <button
+          class="mobile-menu-btn"
+          id="mobileMenuBtn"
+          type="button"
+          aria-label="Open tools"
+        >
+          ☰
+        </button>
+        <div class="editor-mobile-brand" aria-hidden="true">
+          DREAM <span style="color: var(--pantone-yellow)">BOARD</span>
+        </div>
+        <button
+          type="button"
+          class="editor-mobile-lang"
+          id="langBtnEditorMobile"
+          aria-label="Switch language"
+        >
+          RU
+        </button>
+      </div>
       <div class="sidebar-overlay" id="sidebarOverlay"></div>
 
       <div class="app-container">

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -15,6 +15,7 @@ const heroGoButton = document.getElementById("l-go-btn");
 const finalGoButton = document.getElementById("l-final-btn");
 const landingLangButton = document.getElementById("langBtn");
 const editorLangButton = document.getElementById("langBtnEditor");
+const editorMobileLangButton = document.getElementById("langBtnEditorMobile");
 const fileInput = document.getElementById("fileInput");
 const addTextButton = document.getElementById("t-addtext");
 const downloadButton = document.getElementById("t-download");
@@ -159,6 +160,9 @@ function applyLanguageUI() {
   // lang labels (landing + editor)
   document.getElementById("langBtn").innerText = currentLang;
   document.getElementById("langBtnEditor").innerText = currentLang;
+  if (editorMobileLangButton) {
+    editorMobileLangButton.innerText = currentLang;
+  }
 
   // html lang
   document.documentElement.lang = currentLang.toLowerCase();
@@ -216,6 +220,7 @@ function goToEditor() {
   landingView.style.display = "none";
   editorView.style.display = "block";
   document.body.style.overflow = "hidden";
+  closeSidebar();
   requestAnimationFrame(() => {
     resizeCanvasToViewport();
   });
@@ -381,6 +386,7 @@ omFontFamilyBtn.addEventListener("click", (e) => {
 
 landingLangButton?.addEventListener("click", toggleLang);
 editorLangButton?.addEventListener("click", toggleLang);
+editorMobileLangButton?.addEventListener("click", toggleLang);
 heroGoButton?.addEventListener("click", goToEditor);
 finalGoButton?.addEventListener("click", goToEditor);
 addTextButton?.addEventListener("click", addText);
@@ -722,6 +728,8 @@ document.addEventListener("keydown", (e) => {
 });
 
 function hideObjectMenu() {
+  objectMenu.classList.remove("is-mobile-dock");
+  objectMenu.style.maxWidth = "";
   objectMenu.style.display = "none";
 }
 
@@ -775,18 +783,36 @@ function positionObjectMenu() {
 
   applyToolbarTooltips();
   objectMenu.style.display = "flex";
+  objectMenu.classList.toggle("is-mobile-dock", isMobileLayout());
 
-  const rect = obj.getBoundingRect(true, true);
   const canvasRect = canvas.upperCanvasEl.getBoundingClientRect();
 
+  objectMenu.style.left = "0px";
+  objectMenu.style.top = "0px";
+  objectMenu.style.maxWidth = "";
+  const menuRect = objectMenu.getBoundingClientRect();
+
+  if (isMobileLayout()) {
+    const maxDockWidth = Math.max(220, Math.min(canvasRect.width - 20, 360));
+    objectMenu.style.maxWidth = `${maxDockWidth}px`;
+
+    const dockRect = objectMenu.getBoundingClientRect();
+    const dockLeft = Math.max(10, (canvasRect.width - dockRect.width) / 2);
+    const dockTop = Math.max(10, canvasRect.height - dockRect.height - 12);
+
+    objectMenu.style.left = `${dockLeft}px`;
+    objectMenu.style.top = `${dockTop}px`;
+
+    positionColorPopup();
+    positionFontPopup();
+    return;
+  }
+
+  const rect = obj.getBoundingRect(true, true);
   const left = canvasRect.left + rect.left;
   const top = canvasRect.top + rect.top;
   const width = rect.width;
   const height = rect.height;
-
-  objectMenu.style.left = "0px";
-  objectMenu.style.top = "0px";
-  const menuRect = objectMenu.getBoundingClientRect();
 
   const spaceAbove = top - canvasRect.top;
   const spaceBelow = canvasRect.top + canvasRect.height - (top + height);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8,6 +8,8 @@
   --footer-height: 45px;
   --editor-shell-gap: 20px;
   --editor-mobile-header-offset: 68px;
+  --editor-mobile-topbar-height: 74px;
+  --editor-mobile-sheet-gap: 16px;
 
   --landing-bg: #ececec;
   --landing-bg-2: #f3f3f3;
@@ -76,6 +78,34 @@ html {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+}
+
+.editor-mobile-topbar {
+  display: none;
+}
+
+.editor-mobile-brand {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--volcanic-grass);
+  text-transform: uppercase;
+}
+
+.editor-mobile-lang {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 48px;
+  height: 40px;
+  border-radius: 20px;
+  padding: 0 14px;
+  border: 1px solid #e6e6e6;
+  background: #fff;
+  color: var(--volcanic-grass);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.08),
+    0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
 h1 {
@@ -685,6 +715,21 @@ button:hover {
   max-width: 520px;
 }
 
+.object-menu.is-mobile-dock {
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+  border-radius: 24px;
+  padding: 10px;
+  max-width: min(360px, calc(100% - 20px));
+}
+
+.object-menu.is-mobile-dock .om-btn,
+.object-menu.is-mobile-dock #om-fontFamilyBtn,
+.object-menu.is-mobile-dock .om-color-btn {
+  flex: 0 0 auto;
+}
+
 .object-menu .om-btn {
   height: 40px;
   padding: 0 16px;
@@ -1021,11 +1066,10 @@ button:hover {
            MOBILE ADAPTATION (<= 900px) — editor sidebar
            ========================== */
 .mobile-menu-btn {
-  display: none;
-  position: fixed;
-  left: 12px;
-  top: calc(12px + env(safe-area-inset-top));
-  z-index: 250;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: static;
   width: 44px;
   height: 44px;
   border-radius: 22px;
@@ -1053,10 +1097,34 @@ button:hover {
 }
 
 @media (max-width: 900px) {
-  .mobile-menu-btn {
-    display: inline-flex;
+  .editor-mobile-topbar {
+    display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: space-between;
+    gap: 12px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 240;
+    padding: calc(10px + env(safe-area-inset-top)) 14px 10px;
+    min-height: var(--editor-mobile-topbar-height);
+    box-sizing: border-box;
+    background: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  }
+
+  .editor-mobile-topbar .editor-mobile-brand {
+    flex: 1 1 auto;
+    text-align: center;
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+
+  .sidebar-header .lang-switcher {
+    display: none;
   }
 
   .app-container {
@@ -1065,30 +1133,92 @@ button:hover {
 
   .sidebar {
     position: fixed;
-    top: 0;
-    left: 0;
-    width: min(320px, 86vw);
-    height: 100vh;
+    left: 12px;
+    right: 12px;
+    bottom: calc(
+      var(--footer-height) + var(--editor-mobile-sheet-gap) +
+        env(safe-area-inset-bottom)
+    );
+    width: auto;
+    height: auto;
+    max-height: min(
+      420px,
+      calc(
+        100dvh - var(--footer-height) - var(--editor-mobile-topbar-height) -
+          40px
+      )
+    );
     z-index: 200;
-    transform: translateX(-110%);
+    transform: translateY(calc(100% + 24px));
     transition: transform 0.22s ease;
-    box-shadow: 2px 0 18px rgba(0, 0, 0, 0.12);
-    border-right: 1px solid #eee;
-    padding-top: calc(25px + env(safe-area-inset-top));
-    padding-bottom: calc(25px + env(safe-area-inset-bottom));
+    box-shadow: 0 -10px 36px rgba(0, 0, 0, 0.14);
+    border: 1px solid #ececec;
+    border-radius: 28px;
+    padding: 18px 18px calc(18px + env(safe-area-inset-bottom));
+    gap: 16px;
+  }
+
+  .sidebar::before {
+    content: "";
+    width: 44px;
+    height: 5px;
+    border-radius: 999px;
+    background: #d8d8d8;
+    align-self: center;
   }
 
   .sidebar.is-open {
-    transform: translateX(0);
+    transform: translateY(0);
   }
 
   .sidebar-overlay.is-open {
     display: block;
   }
 
+  .sidebar-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    padding-top: 2px;
+    padding-bottom: 10px;
+    background: linear-gradient(
+      180deg,
+      #ffffff 0%,
+      rgba(255, 255, 255, 0.92) 100%
+    );
+  }
+
+  .control-group {
+    gap: 12px;
+    padding-bottom: 0;
+    border-bottom: none;
+  }
+
+  .control-group button,
+  .file-input-label {
+    min-height: 48px;
+    border-radius: 24px;
+    font-size: 13px;
+  }
+
   .canvas-area {
-    padding: calc(var(--editor-mobile-header-offset) + env(safe-area-inset-top))
-      16px calc(16px + env(safe-area-inset-bottom));
+    padding: calc(
+        var(--editor-mobile-topbar-height) + env(safe-area-inset-top) + 14px
+      )
+      14px calc(var(--footer-height) + 22px + env(safe-area-inset-bottom));
+  }
+
+  .canvas-wrapper {
+    width: 100%;
+    border-radius: 28px;
+    overflow: hidden;
+  }
+
+  .object-menu.is-mobile-dock {
+    width: calc(100% - 20px);
+    border-radius: 26px;
+    padding: 12px;
+    gap: 8px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated mobile editor top bar and bottom-sheet tools panel
- dock the object menu for phone layouts instead of floating it near the selection
- update frontend docs for the new mobile interaction model

## Testing
- npm run ci
- curl -s http://127.0.0.1:4173/ | rg -n "editor-mobile-topbar|langBtnEditorMobile|mobile-menu-btn" -n