### PR TITLE
chore: add dreamboard process memory and macOS runner flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to validate
+        required: false
+        default: ""
+        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -21,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -9,6 +9,14 @@ on:
         description: Git ref to check
         required: false
         type: string
+      head_ref:
+        description: PR head ref to compare
+        required: false
+        type: string
+      base_ref:
+        description: PR base ref to compare
+        required: false
+        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -28,15 +36,30 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+
+      - name: Resolve diff refs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_ref="${{ github.event.pull_request.base.sha }}"
+            head_ref="${{ github.event.pull_request.head.sha }}"
+          else
+            base_ref="${{ inputs.base_ref || 'HEAD~1' }}"
+            head_ref="${{ inputs.head_ref || 'HEAD' }}"
+          fi
+
+          echo "BASE_REF=$base_ref" >> "$GITHUB_ENV"
+          echo "HEAD_REF=$head_ref" >> "$GITHUB_ENV"
 
       - name: Check docs coverage for product and infra changes
         shell: bash
         run: |
           set -euo pipefail
 
-          base="${{ github.event.pull_request.base.sha || 'HEAD~1' }}"
-          changed=$(git diff --name-only "$base"...HEAD)
+          changed=$(git diff --name-only "$BASE_REF"... "$HEAD_REF")
 
           echo "Changed files:"
           echo "$changed"
@@ -72,6 +95,7 @@ jobs:
             echo ""
             echo "When modifying index.html, scripts/, build config, or future app source — update at least one of:"
             echo "  - docs_dreamboard/"
+            echo "  - specs/<feature-id>/"
             echo "  - AGENTS.md or CLAUDE.md"
             echo "  - .github/workflows/ (if orchestration changed)"
             echo ""
@@ -79,6 +103,9 @@ jobs:
           fi
 
           echo "Docs coverage OK."
+
+      - name: Require complete feature memory for product changes
+        run: node scripts/check-feature-memory.mjs "$BASE_REF" "$HEAD_REF"
 
       - name: Verify required baseline files exist
         uses: actions/setup-node@v4

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          changed=$(git diff --name-only "$BASE_REF"... "$HEAD_REF")
+          changed=$(git diff --name-only "${BASE_REF}...${HEAD_REF}")
 
           echo "Changed files:"
           echo "$changed"

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 node_modules/
 dist/
 .vercel/
-
+.codex/

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,81 @@
+# dreamboard Process Constitution
+
+## Purpose
+
+This repository uses a lightweight spec-driven and AI-assisted delivery model.
+The goal is to make frontend work resumable, reviewable, and safe to ship
+through Vercel without relying on hidden session memory.
+
+## Non-Negotiable Rules
+
+1. Repository memory over session memory.
+   Durable intent and operating rules live in `.specify/`, `docs_dreamboard/`,
+   `specs/`, workflows, and tests.
+2. Specs before product code.
+   Before changing the landing page, editor behavior, build contract, or deploy
+   behavior, create or update one active `specs/<feature-id>/` folder with
+   `spec.md`, `plan.md`, and `tasks.md`.
+3. Pull requests only.
+   Product changes land through pull requests with green required checks.
+4. One worker, one worktree, one branch, one PR.
+   Local implementation loops must run in isolated macOS worktrees instead of
+   the main checkout.
+5. Merge-ready means the full loop is green.
+   A task is done only when the current PR head SHA has green
+   `baseline-checks`, `guard`, and `AI Review`, no unresolved blocking review
+   findings, and a healthy Vercel preview for the changed scope.
+6. Production changes come from Git only.
+   No direct edits in Vercel or the browser; production updates happen only
+   through merge to `main` and Vercel Git integration.
+7. Documentation moves with behavior.
+   Changes to app behavior, orchestration, CI/CD, or architecture must update
+   durable docs in the same PR.
+8. Mobile-first quality bar.
+   The site must remain usable on iPhone-sized screens, keep editor state safe,
+   and preserve export/download behavior.
+
+## Memory Layers
+
+- `.specify/`
+  Process constitution and future reusable templates.
+- `docs_dreamboard/`
+  Durable product, frontend, deployment, and orchestration context.
+- `specs/<feature-id>/`
+  Active feature intent, implementation plan, and execution state.
+
+## Roles
+
+- User
+  Sets goals, approves product direction, and remains the final merge authority.
+- Codex
+  Owns architecture, orchestration, CI/CD health, repository memory, and can be
+  the selected implementation agent.
+- Claude
+  Optional implementation or review agent when the repository secret
+  `ANTHROPIC_API_KEY` is configured.
+- Gemini
+  Default native review backend on GitHub.
+- GitHub Actions + Vercel
+  Execute required checks, review normalization, previews, and production
+  deployment.
+
+## Standard Feature Loop
+
+1. Sync from current `main`.
+2. Create or update one active `specs/<feature-id>/` folder.
+3. Select the implementation and review policy for the task.
+4. Create an isolated macOS worktree and branch.
+5. Generate the implementation prompt from repository memory.
+6. Implement the scoped change on that branch only.
+7. Update `tasks.md`, tests, and durable docs.
+8. Open or update the same PR.
+9. Wait for `baseline-checks`, `guard`, `AI Review`, and Vercel preview.
+10. Iterate on the same branch until the PR is merge-ready.
+
+## macOS Local Runner Contract
+
+- Local orchestration is repository-owned and documented in
+  `docs_dreamboard/project/devops/macos-local-runners.md`.
+- Local agent selection state is stored under `.codex/` and is gitignored.
+- Scripts may prepare prompts, worktrees, and PR publishing, but they must not
+  bypass the PR loop or GitHub checks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,28 +13,40 @@
 
 ## Current Phase & Status
 
-| Area                          | Status                                             |
-| ----------------------------- | -------------------------------------------------- |
-| Product prototype             | COMPLETE                                           |
-| Static landing + editor       | COMPLETE                                           |
-| Mobile adaptation             | PARTIAL — needs redesign                           |
-| Frontend architecture cleanup | UPCOMING                                           |
-| CI / AI review orchestration  | COMPLETE after infra PR                            |
-| Production deploy flow        | COMPLETE via Vercel Git integration after infra PR |
+| Area                                      | Status                              |
+| ----------------------------------------- | ----------------------------------- |
+| Product prototype                         | COMPLETE                            |
+| Static landing + editor                   | COMPLETE                            |
+| Mobile adaptation                         | PARTIAL — ongoing iteration         |
+| Frontend architecture cleanup             | UPCOMING                            |
+| Repository memory and feature-memory flow | IN PROGRESS                         |
+| CI / AI review orchestration              | COMPLETE                            |
+| Production deploy flow                    | COMPLETE via Vercel Git integration |
 
 ## Project Structure
 
 ```
 dreamboard/
-├── index.html                          # Current app: landing + editor + styles + scripts
-├── package.json                        # Repo tooling for CI and Vercel build
+├── .specify/
+│   └── memory/constitution.md          # Process contract and non-negotiable rules
+├── specs/
+│   └── <feature-id>/                   # Feature memory: spec.md, plan.md, tasks.md
+├── index.html                          # Current app shell
+├── package.json                        # Repo tooling for CI, local orchestration, and build
 ├── vercel.json                         # Vercel build/output configuration
 ├── scripts/
 │   ├── build-static.mjs                # Static build to dist/
 │   ├── check-static-baseline.mjs       # Repository baseline checks
+│   ├── check-feature-memory.mjs        # Product change -> complete specs folder enforcement
+│   ├── set-implementation-agent.mjs    # Local + GitHub agent policy helper
+│   ├── new-worktree.mjs                # macOS local worktree helper
+│   ├── start-implementation-worker.mjs # Prompt preparation helper
+│   ├── publish-branch.mjs              # Push branch and open or reuse PR
 │   ├── resolve-pr-context.mjs          # Pull request context resolver for workflows
 │   └── ai-review-gate.mjs              # Review gate for Codex/Claude
 ├── docs_dreamboard/
+│   ├── README.md                       # Durable docs index
+│   ├── adr/                            # Architecture decision records
 │   ├── project-idea.md                 # Product overview and roadmap
 │   └── project/
 │       ├── frontend/frontend-docs.md   # Frontend architecture notes
@@ -45,9 +57,12 @@ dreamboard/
 ## Delivery Workflow
 
 - All code changes land through pull requests.
+- Product-code work starts from an active `specs/<feature-id>/` folder.
+- One implementation loop uses one worktree, one branch, and one PR.
 - Required GitHub checks are `baseline-checks`, `guard`, and `AI Review`.
 - Vercel handles preview deployments for pull requests and production deployment for `main` through Git integration.
 - Durable workflow docs live under `docs_dreamboard/project/devops/`.
+- Local orchestration state lives under `.codex/` and is gitignored.
 - Agent selection is policy-driven through repository variables:
   - `AI_IMPLEMENTATION_AGENT`
   - `AI_REVIEW_AGENT`
@@ -78,24 +93,38 @@ No direct production edits in Vercel or the browser. Product changes must be mad
 
 ### 2. Keep durable docs in sync
 
-When updating `index.html`, `scripts/`, workflow behavior, or deployment configuration, update at least one relevant file under `docs_dreamboard/`, `AGENTS.md`, or `CLAUDE.md`.
+When updating `index.html`, `src/`, runtime behavior, workflows, or deploy
+configuration, update the active `specs/<feature-id>/` folder and at least one
+relevant durable doc under `docs_dreamboard/`, `AGENTS.md`, or `CLAUDE.md`.
 
 ### 3. Preserve static-site deployability
 
 Even while the app is still a single-file prototype, changes must keep `npm run build` producing a deployable `dist/index.html` artifact for Vercel.
 
-### 4. Gemini review config is repository-owned
+### 4. One worker equals one worktree
 
-Gemini review behavior is configured through `.gemini/config.yaml` and `.gemini/styleguide.md`. Keep those files in sync with the repository review contract.
+Do not run parallel implementation work in the main checkout. Use the local
+macOS runner flow from `docs_dreamboard/project/devops/macos-local-runners.md`.
 
-### 5. Frontend changes should improve mobile, not patch around it
+### 5. Gemini review config is repository-owned
+
+Gemini review behavior is configured through `.gemini/config.yaml` and
+`.gemini/styleguide.md`. Keep those files in sync with the repository review
+contract.
+
+### 6. Frontend changes should improve mobile, not patch around it
 
 Avoid adding more fixed-size offsets and viewport hacks unless strictly necessary. Prefer layout systems that can survive later migration to a modular frontend app.
 
 ## Reading Route — Implementing a Change
 
-1. `docs_dreamboard/project-idea.md`
-2. `docs_dreamboard/project/frontend/frontend-docs.md`
-3. `docs_dreamboard/project/devops/ai-orchestration-protocol.md`
-4. `index.html`
-5. Existing workflows and scripts
+1. `.specify/memory/constitution.md`
+2. `docs_dreamboard/README.md`
+3. `docs_dreamboard/project-idea.md`
+4. `docs_dreamboard/project/frontend/frontend-docs.md`
+5. `docs_dreamboard/project/devops/ai-orchestration-protocol.md`
+6. `docs_dreamboard/project/devops/ai-pr-workflow.md`
+7. `specs/<feature-id>/spec.md`
+8. `specs/<feature-id>/plan.md`
+9. `specs/<feature-id>/tasks.md`
+10. Relevant app files and scripts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,21 +8,28 @@
 - Fabric.js через CDN
 - Vercel Git integration для preview и production deploy
 - GitHub Actions для CI, guard и AI review orchestration
+- `.specify/`, `docs_dreamboard/` и `specs/` как repository memory
 - Gemini Code Assist как default review backend
 
 ## Важные правила
 
 - Источник истины — репозиторий, а не ручные правки в Vercel
 - Все изменения проходят через PR
-- При изменении поведения UI, workflow или build/deploy обновляй `docs_dreamboard/`
+- Продуктовые изменения начинаются с активной папки `specs/<feature-id>/`
+- Один implementation loop = один worktree, одна ветка и один PR
+- При изменении поведения UI, workflow или build/deploy обновляй `specs/` и `docs_dreamboard/`
 - Не ломай `npm run build`: проект должен оставаться deployable как статический сайт
 - При review фокусируйся на mobile layout, editor behavior, export safety, i18n consistency и maintainability
 
 ## Документация
 
+- Конституция процесса: `.specify/memory/constitution.md`
+- Карта docs: `docs_dreamboard/README.md`
 - Идея проекта: `docs_dreamboard/project-idea.md`
 - Frontend: `docs_dreamboard/project/frontend/frontend-docs.md`
 - Orchestration: `docs_dreamboard/project/devops/ai-orchestration-protocol.md`
+- PR loop: `docs_dreamboard/project/devops/ai-pr-workflow.md`
+- Local runners: `docs_dreamboard/project/devops/macos-local-runners.md`
 - AI runner: `docs_dreamboard/project/devops/ai-runner.md`
 - Review contract: `docs_dreamboard/project/devops/review-contract.md`
 - Vercel CD: `docs_dreamboard/project/devops/vercel-cd.md`

--- a/docs_dreamboard/README.md
+++ b/docs_dreamboard/README.md
@@ -1,0 +1,35 @@
+# dreamboard Docs Map
+
+`docs_dreamboard/` is the durable memory layer for this repository.
+
+## What belongs here
+
+- stable product context
+- frontend architecture decisions
+- delivery and deployment rules
+- review and orchestration contracts
+- ADRs and operating playbooks
+
+## Main reading order
+
+1. `.specify/memory/constitution.md`
+2. `docs_dreamboard/project-idea.md`
+3. `docs_dreamboard/project/frontend/frontend-docs.md`
+4. `docs_dreamboard/project/devops/ai-orchestration-protocol.md`
+5. `docs_dreamboard/project/devops/ai-runner.md`
+6. `docs_dreamboard/project/devops/ai-pr-workflow.md`
+7. `docs_dreamboard/project/devops/macos-local-runners.md`
+8. `specs/<feature-id>/spec.md`
+9. `specs/<feature-id>/plan.md`
+10. `specs/<feature-id>/tasks.md`
+
+## Structure
+
+- `adr/`
+  Architecture decision records and cross-cutting technical choices
+- `project-idea.md`
+  Product goals and current roadmap
+- `project/frontend/`
+  Frontend architecture and UI behavior notes
+- `project/devops/`
+  CI/CD, review, orchestration, and delivery workflow

--- a/docs_dreamboard/adr/README.md
+++ b/docs_dreamboard/adr/README.md
@@ -1,0 +1,12 @@
+# dreamboard ADRs
+
+This folder stores durable cross-cutting decisions that should survive
+individual feature PRs.
+
+Examples:
+
+- framework migrations
+- storage or persistence strategy
+- deployment model changes
+- editor architecture changes
+- agent orchestration changes that affect repository policy

--- a/docs_dreamboard/project-idea.md
+++ b/docs_dreamboard/project-idea.md
@@ -21,13 +21,15 @@ The current app is a strong prototype, and the repository is now on a safer refa
 
 ## Infra Goal
 
-Before refactoring the application itself, the repository must follow the standard delivery path:
+Before deeper refactoring, the repository must follow the standard delivery path:
 
 1. PR-only changes
 2. required checks in GitHub
 3. AI review routing through repository policy with Gemini as the default reviewer
 4. Vercel preview deploys on PR
 5. Vercel production deploys on merge to `main`
+6. repository memory through `.specify/`, `docs_dreamboard/`, and `specs/`
+7. local macOS worktree orchestration for implementation tasks
 
 ## Next Product Goal
 

--- a/docs_dreamboard/project/devops/ai-orchestration-protocol.md
+++ b/docs_dreamboard/project/devops/ai-orchestration-protocol.md
@@ -4,6 +4,12 @@
 
 `dreamboard` uses a PR-only delivery model.
 
+Repository memory is split into:
+
+- `.specify/` for process constitution
+- `docs_dreamboard/` for durable product and devops context
+- `specs/<feature-id>/` for active feature intent, plan, and task state
+
 Required GitHub checks:
 
 - `baseline-checks`
@@ -29,6 +35,17 @@ Default policy in this repository:
 Gemini is the canonical default review backend for this repository because it is already installed on GitHub and runs natively on pull requests.
 
 Claude remains supported as an optional backend when `ANTHROPIC_API_KEY` is configured and the repository variable is switched.
+
+## Local macOS Orchestration
+
+Implementation work is prepared locally through repository-owned macOS helpers:
+
+- `scripts/set-implementation-agent.mjs`
+- `scripts/new-worktree.mjs`
+- `scripts/start-implementation-worker.mjs`
+- `scripts/publish-branch.mjs`
+
+One task should map to one worktree, one branch, and one PR.
 
 ## Native Execution Surface
 

--- a/docs_dreamboard/project/devops/ai-pr-workflow.md
+++ b/docs_dreamboard/project/devops/ai-pr-workflow.md
@@ -1,0 +1,66 @@
+# AI Pull Request Workflow
+
+This is the canonical PR loop for `dreamboard`.
+
+## Roles
+
+- Codex owns architecture, repository memory, CI/CD health, and local
+  orchestration.
+- The selected implementation agent writes scoped code on a feature branch.
+- GitHub Actions runs `baseline-checks`, `guard`, and `AI Review`.
+- Vercel provides preview deployments for PRs and production deploy on merge to
+  `main`.
+- A human remains the final merge authority.
+
+## Standard Loop
+
+1. Start from current `main`.
+2. Create or update one active `specs/<feature-id>/` folder.
+3. Create an isolated macOS worktree for the task.
+4. Select the implementation and review agents for the branch.
+5. Generate the implementation prompt from repository memory.
+6. Implement only the scoped change on that branch.
+7. Update `tasks.md`, docs, and tests or validation notes in the same PR.
+8. Open or update the same PR.
+9. Wait for:
+   - `baseline-checks`
+   - `guard`
+   - `AI Review`
+   - healthy Vercel preview deployment
+10. Keep fixing the same branch until only human approval and merge remain.
+
+## Hard Gates
+
+- Product changes in `index.html`, `src/`, future app code, or runtime config do
+  not start without an active `specs/<feature-id>/` folder.
+- Local product edits in the main checkout do not count as completed work.
+- If the selected implementation agent path is unavailable, stop and report the
+  blocker instead of bypassing the loop.
+- A PR is not done while required checks are queued, running, or red.
+
+## Review Contract
+
+- Reviewer selection comes only from `AI_REVIEW_AGENT`.
+- Supported review backends are `gemini`, `codex`, and `claude`.
+- `AI Review` is the normalized required check regardless of the backend.
+- Low-severity-only findings are advisory and non-blocking.
+- Manual Gemini review commands stay native-only; rerunning the PR-linked
+  `AI Review` workflow is enough to reuse same-head Gemini output.
+
+## Merge-Ready Definition
+
+The current PR head SHA is merge-ready only when:
+
+- `baseline-checks` is green
+- `guard` is green
+- `AI Review` is green
+- Vercel preview is healthy for the changed flow
+- no blocking review findings remain unresolved
+- no merge conflicts remain
+
+## Related Docs
+
+- `docs_dreamboard/project/devops/macos-local-runners.md`
+- `docs_dreamboard/project/devops/ai-orchestration-protocol.md`
+- `docs_dreamboard/project/devops/vercel-cd.md`
+- `docs_dreamboard/project/devops/delivery-playbook.md`

--- a/docs_dreamboard/project/devops/ai-runner.md
+++ b/docs_dreamboard/project/devops/ai-runner.md
@@ -62,6 +62,8 @@ without a complete `specs/<feature-id>/` update.
 For `dreamboard`, product-code paths are:
 
 - `index.html`
+- `package.json` and `package-lock.json`
+- `scripts/`
 - `src/`
 - future `app/`, `public/`, and `assets/` folders
 - `vercel.json`

--- a/docs_dreamboard/project/devops/ai-runner.md
+++ b/docs_dreamboard/project/devops/ai-runner.md
@@ -12,6 +12,11 @@ If a variable is unset, the workflows fall back to repository defaults:
 - implementation: `codex`
 - review: `gemini`
 
+Local macOS helper scripts may also store the current selection under:
+
+- `.codex/implementation-agent`
+- `.codex/review-agent`
+
 ## Claude Requirements
 
 Claude paths require repository secret:
@@ -48,6 +53,18 @@ The gate fails on:
 - Gemini `CHANGES_REQUESTED`
 - Gemini inline findings with highest severity `Critical`, `High`, or `Medium`
 - setup/runtime failures for the selected backend
+
+## Feature Memory Gate
+
+`guard` is also responsible for ensuring that product-code changes do not land
+without a complete `specs/<feature-id>/` update.
+
+For `dreamboard`, product-code paths are:
+
+- `index.html`
+- `src/`
+- future `app/`, `public/`, and `assets/` folders
+- `vercel.json`
 
 ## Gemini Operational Note
 

--- a/docs_dreamboard/project/devops/ai-runner.md
+++ b/docs_dreamboard/project/devops/ai-runner.md
@@ -63,6 +63,8 @@ For `dreamboard`, product-code paths are:
 
 - `index.html`
 - `package.json` and `package-lock.json`
+- `.htmlvalidate.json`
+- `.github/workflows/`
 - `scripts/`
 - `src/`
 - future `app/`, `public/`, and `assets/` folders

--- a/docs_dreamboard/project/devops/delivery-playbook.md
+++ b/docs_dreamboard/project/devops/delivery-playbook.md
@@ -1,0 +1,37 @@
+# Delivery Playbook
+
+This playbook covers preview validation before merge and production smoke after
+merge.
+
+## Preview Checklist
+
+For any app-facing PR, verify on the Vercel preview:
+
+- landing page loads without layout breakage
+- editor opens and renders the Fabric canvas
+- primary mobile viewport still works
+- back navigation, export, and save flows behave as expected for the changed
+  scope
+- no obvious missing assets or broken links appear
+
+## Merge Rule
+
+Do not merge while any of these are true:
+
+- required GitHub checks are pending or failing
+- the active review backend has unresolved blocking findings
+- the Vercel preview is failing or visibly broken for the changed flow
+
+## Production Smoke
+
+After merge to `main`, verify the production URL documented in
+`VERCEL_PRODUCTION_DOMAIN`.
+
+Minimum smoke:
+
+- landing page responds
+- editor can be opened
+- critical changed feature still behaves on desktop and mobile
+
+If production smoke fails, treat it as an active incident and recover through a
+new PR rather than a direct Vercel dashboard edit.

--- a/docs_dreamboard/project/devops/macos-local-runners.md
+++ b/docs_dreamboard/project/devops/macos-local-runners.md
@@ -1,0 +1,80 @@
+# macOS Local Runners
+
+This document adapts the local worker orchestration pattern to macOS for
+`dreamboard`.
+
+## Purpose
+
+Local runners are not GitHub self-hosted runners. They are the repository-owned
+macOS helpers for:
+
+- selecting implementation and review policy
+- creating isolated worktrees
+- preparing high-signal implementation prompts
+- publishing the active branch to a draft PR
+
+## Rules
+
+- One task equals one worktree, one branch, and one PR.
+- Never run multiple implementation loops inside the main checkout.
+- Start each worktree from current `main`.
+- Keep prompts tied to one active `specs/<feature-id>/` folder.
+- Use the scripts to prepare and publish work, but never bypass GitHub checks.
+
+## Prerequisites
+
+- macOS with `git`, `gh`, and Node.js 24 available
+- authenticated GitHub CLI for repository variable updates and PR creation
+- Codex app or Claude Code available locally when you want to hand off the
+  prepared prompt
+
+## Local State
+
+The scripts keep local orchestration state in `.codex/`:
+
+- `.codex/implementation-agent`
+- `.codex/review-agent`
+- `.codex/prompts/`
+
+This directory is local-only and gitignored.
+
+## Recommended Flow
+
+1. Select policy.
+
+```bash
+node scripts/set-implementation-agent.mjs --implementation codex --review gemini
+```
+
+2. Create a new isolated worktree.
+
+```bash
+node scripts/new-worktree.mjs --feature 001-process-memory-and-macos-runners
+```
+
+3. Change into the created worktree.
+
+4. Generate the implementation prompt and copy it to the clipboard.
+
+```bash
+node scripts/start-implementation-worker.mjs \
+  --feature 001-process-memory-and-macos-runners \
+  --copy
+```
+
+5. Run the selected implementation agent using that prompt.
+
+6. Publish the branch and open or reuse a draft PR.
+
+```bash
+node scripts/publish-branch.mjs \
+  --feature 001-process-memory-and-macos-runners \
+  --title "chore: add dreamboard process memory and macOS local runner flow"
+```
+
+## Trade-Offs
+
+- The repository prepares prompts and branch/worktree state, but it does not
+  force-launch a specific local app.
+- Claude review remains unavailable until `ANTHROPIC_API_KEY` is configured in
+  GitHub repository secrets.

--- a/docs_dreamboard/project/devops/review-contract.md
+++ b/docs_dreamboard/project/devops/review-contract.md
@@ -35,6 +35,7 @@ For `dreamboard`, reviewers should prioritize:
 - mobile layout regressions
 - canvas/editor correctness
 - export behavior
+- draft persistence and state safety
 - i18n regressions
 - build/deploy safety
 - maintainability risks in the static app

--- a/docs_dreamboard/project/devops/vercel-cd.md
+++ b/docs_dreamboard/project/devops/vercel-cd.md
@@ -36,3 +36,6 @@ Do not treat manual dashboard edits as the delivery path. Product behavior shoul
 2. PR checks
 3. merge to `main`
 4. Vercel production deploy from the merged commit
+
+Preview validation and post-merge smoke are documented in
+`docs_dreamboard/project/devops/delivery-playbook.md`.

--- a/docs_dreamboard/project/frontend/frontend-docs.md
+++ b/docs_dreamboard/project/frontend/frontend-docs.md
@@ -14,6 +14,17 @@ The current application is still a static frontend, but it is no longer entirely
 
 This keeps the repo deployable as a static site while making future extraction to components and a typed frontend stack much safer.
 
+## Repository Memory and Feature Loop
+
+Frontend work now follows the repository memory contract:
+
+- process rules live in `.specify/memory/constitution.md`
+- durable frontend and delivery context lives in `docs_dreamboard/`
+- active implementation scope lives in `specs/<feature-id>/`
+
+UI or editor changes should start by updating the active feature folder before
+touching product code.
+
 ## Responsive Behavior
 
 The editor now uses container-based canvas sizing instead of raw viewport math:

--- a/package.json
+++ b/package.json
@@ -4,11 +4,16 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "agent:set": "node scripts/set-implementation-agent.mjs",
     "build": "node scripts/build-static.mjs",
+    "check:feature-memory": "node scripts/check-feature-memory.mjs",
     "check:repo": "node scripts/check-static-baseline.mjs",
     "check:html": "html-validate index.html",
-    "format:check": "prettier --check \"index.html\" \"src/**/*.{css,js}\" \"AGENTS.md\" \"CLAUDE.md\" \"docs_dreamboard/**/*.md\" \".github/workflows/*.{yml,yaml}\" \".gemini/**/*.{md,yaml,yml}\" \"scripts/**/*.mjs\" \"package.json\" \"vercel.json\" \".htmlvalidate.json\"",
-    "ci": "npm run check:repo && npm run check:html && npm run build && npm run format:check"
+    "format:check": "prettier --check \"index.html\" \"src/**/*.{css,js}\" \"AGENTS.md\" \"CLAUDE.md\" \".specify/**/*.md\" \"specs/**/*.md\" \"docs_dreamboard/**/*.md\" \".github/workflows/*.{yml,yaml}\" \".gemini/**/*.{md,yaml,yml}\" \"scripts/**/*.mjs\" \"package.json\" \"vercel.json\" \".htmlvalidate.json\"",
+    "ci": "npm run check:repo && npm run check:html && npm run build && npm run format:check",
+    "pr:publish": "node scripts/publish-branch.mjs",
+    "worker:start": "node scripts/start-implementation-worker.mjs",
+    "worktree:new": "node scripts/new-worktree.mjs"
   },
   "devDependencies": {
     "html-validate": "^10.11.3",

--- a/scripts/check-feature-memory.mjs
+++ b/scripts/check-feature-memory.mjs
@@ -24,7 +24,14 @@ const hasRef = (ref) => {
   }
 };
 
-const defaultBaseRef = hasRef("origin/main") ? "origin/main" : "HEAD~1";
+const preferredBaseRef = process.env.GITHUB_BASE_REF
+  ? `origin/${process.env.GITHUB_BASE_REF}`
+  : "origin/main";
+const defaultBaseRef = hasRef(preferredBaseRef)
+  ? preferredBaseRef
+  : hasRef("origin/main")
+    ? "origin/main"
+    : "HEAD~1";
 const [baseRef = defaultBaseRef, headRef = "HEAD"] = filteredArgs;
 
 const diffArgs = inspectWorktree
@@ -36,6 +43,8 @@ const changedFiles = git(diffArgs)
   .map((file) => file.trim())
   .filter(Boolean);
 
+// Build-contract and repository-owned orchestration changes should participate
+// in the same feature-memory rule as UI code.
 const isProductPath = (file) =>
   file === "index.html" ||
   file === "package.json" ||

--- a/scripts/check-feature-memory.mjs
+++ b/scripts/check-feature-memory.mjs
@@ -1,21 +1,24 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 
 const args = process.argv.slice(2);
 const inspectWorktree = args.includes("--worktree");
 const filteredArgs = args.filter((arg) => arg !== "--worktree");
+const repoRoot = resolve(process.cwd());
 
 const git = (args) =>
   execFileSync("git", args, {
-    cwd: process.cwd(),
+    cwd: repoRoot,
     encoding: "utf8",
   }).trim();
 
 const hasRef = (ref) => {
   try {
     execFileSync("git", ["rev-parse", "--verify", ref], {
-      cwd: process.cwd(),
+      cwd: repoRoot,
       stdio: "ignore",
     });
     return true;
@@ -24,15 +27,21 @@ const hasRef = (ref) => {
   }
 };
 
+const [
+  baseRefInput = process.env.GITHUB_BASE_REF || "origin/main",
+  headRef = "HEAD",
+] = filteredArgs;
+
 const preferredBaseRef = process.env.GITHUB_BASE_REF
   ? `origin/${process.env.GITHUB_BASE_REF}`
   : "origin/main";
-const defaultBaseRef = hasRef(preferredBaseRef)
-  ? preferredBaseRef
-  : hasRef("origin/main")
-    ? "origin/main"
-    : "HEAD~1";
-const [baseRef = defaultBaseRef, headRef = "HEAD"] = filteredArgs;
+const baseRef = hasRef(baseRefInput)
+  ? baseRefInput
+  : hasRef(preferredBaseRef)
+    ? preferredBaseRef
+    : hasRef("origin/main")
+      ? "origin/main"
+      : "HEAD~1";
 
 const diffArgs = inspectWorktree
   ? ["diff", "--name-only", "HEAD"]
@@ -50,6 +59,8 @@ const isProductPath = (file) =>
   file === "package.json" ||
   file === "package-lock.json" ||
   file === "vercel.json" ||
+  file === ".htmlvalidate.json" ||
+  file.startsWith(".github/workflows/") ||
   file.startsWith("scripts/") ||
   file.startsWith("src/") ||
   file.startsWith("app/") ||
@@ -61,32 +72,27 @@ if (!changedFiles.some(isProductPath)) {
   process.exit(0);
 }
 
-const featureCoverage = new Map();
+const featureIds = new Set();
 
 for (const file of changedFiles) {
-  const match = file.match(/^specs\/([^/]+)\/(spec|plan|tasks)\.md$/);
+  const match = file.match(/^specs\/([^/]+)\//);
   if (!match) {
     continue;
   }
 
-  const [, featureId, kind] = match;
-  const current = featureCoverage.get(featureId) || {
-    spec: false,
-    plan: false,
-    tasks: false,
-  };
-
-  current[kind] = true;
-  featureCoverage.set(featureId, current);
+  featureIds.add(match[1]);
 }
 
-const validFeature = [...featureCoverage.entries()].find(
-  ([, files]) => files.spec && files.plan && files.tasks,
-);
+const hasCompleteFeatureMemory = (featureId) =>
+  existsSync(resolve(repoRoot, "specs", featureId, "spec.md")) &&
+  existsSync(resolve(repoRoot, "specs", featureId, "plan.md")) &&
+  existsSync(resolve(repoRoot, "specs", featureId, "tasks.md"));
+
+const validFeature = [...featureIds].find(hasCompleteFeatureMemory);
 
 if (validFeature) {
   console.log(
-    `Feature-memory gate passed via specs/${validFeature[0]}/{spec,plan,tasks}.md`,
+    `Feature-memory gate passed via specs/${validFeature}/{spec,plan,tasks}.md`,
   );
   process.exit(0);
 }
@@ -98,14 +104,16 @@ console.error(
   "Touch one specs/<feature-id>/ folder with spec.md, plan.md, and tasks.md in the same PR.",
 );
 
-if (featureCoverage.size > 0) {
-  console.error("Observed feature-memory changes:");
-  for (const [featureId, files] of featureCoverage.entries()) {
-    const touched = Object.entries(files)
-      .filter(([, touchedFlag]) => touchedFlag)
-      .map(([name]) => `${name}.md`)
-      .join(", ");
-    console.error(`- ${featureId}: ${touched || "no complete files"}`);
+if (featureIds.size > 0) {
+  console.error("Observed feature-memory folders:");
+  for (const featureId of featureIds) {
+    console.error(
+      `- ${featureId}: ${
+        hasCompleteFeatureMemory(featureId)
+          ? "complete feature memory present"
+          : "missing one or more of spec.md, plan.md, tasks.md"
+      }`,
+    );
   }
 }
 

--- a/scripts/check-feature-memory.mjs
+++ b/scripts/check-feature-memory.mjs
@@ -5,13 +5,27 @@ import { execFileSync } from "node:child_process";
 const args = process.argv.slice(2);
 const inspectWorktree = args.includes("--worktree");
 const filteredArgs = args.filter((arg) => arg !== "--worktree");
-const [baseRef = "HEAD~1", headRef = "HEAD"] = filteredArgs;
 
 const git = (args) =>
   execFileSync("git", args, {
     cwd: process.cwd(),
     encoding: "utf8",
   }).trim();
+
+const hasRef = (ref) => {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", ref], {
+      cwd: process.cwd(),
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const defaultBaseRef = hasRef("origin/main") ? "origin/main" : "HEAD~1";
+const [baseRef = defaultBaseRef, headRef = "HEAD"] = filteredArgs;
 
 const diffArgs = inspectWorktree
   ? ["diff", "--name-only", "HEAD"]
@@ -24,7 +38,10 @@ const changedFiles = git(diffArgs)
 
 const isProductPath = (file) =>
   file === "index.html" ||
+  file === "package.json" ||
+  file === "package-lock.json" ||
   file === "vercel.json" ||
+  file.startsWith("scripts/") ||
   file.startsWith("src/") ||
   file.startsWith("app/") ||
   file.startsWith("public/") ||

--- a/scripts/check-feature-memory.mjs
+++ b/scripts/check-feature-memory.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+const inspectWorktree = args.includes("--worktree");
+const filteredArgs = args.filter((arg) => arg !== "--worktree");
+const [baseRef = "HEAD~1", headRef = "HEAD"] = filteredArgs;
+
+const git = (args) =>
+  execFileSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  }).trim();
+
+const diffArgs = inspectWorktree
+  ? ["diff", "--name-only", "HEAD"]
+  : ["diff", "--name-only", `${baseRef}...${headRef}`];
+
+const changedFiles = git(diffArgs)
+  .split(/\r?\n/)
+  .map((file) => file.trim())
+  .filter(Boolean);
+
+const isProductPath = (file) =>
+  file === "index.html" ||
+  file === "vercel.json" ||
+  file.startsWith("src/") ||
+  file.startsWith("app/") ||
+  file.startsWith("public/") ||
+  file.startsWith("assets/");
+
+if (!changedFiles.some(isProductPath)) {
+  console.log("No product paths changed; feature-memory gate passes.");
+  process.exit(0);
+}
+
+const featureCoverage = new Map();
+
+for (const file of changedFiles) {
+  const match = file.match(/^specs\/([^/]+)\/(spec|plan|tasks)\.md$/);
+  if (!match) {
+    continue;
+  }
+
+  const [, featureId, kind] = match;
+  const current = featureCoverage.get(featureId) || {
+    spec: false,
+    plan: false,
+    tasks: false,
+  };
+
+  current[kind] = true;
+  featureCoverage.set(featureId, current);
+}
+
+const validFeature = [...featureCoverage.entries()].find(
+  ([, files]) => files.spec && files.plan && files.tasks,
+);
+
+if (validFeature) {
+  console.log(
+    `Feature-memory gate passed via specs/${validFeature[0]}/{spec,plan,tasks}.md`,
+  );
+  process.exit(0);
+}
+
+console.error(
+  "Product paths changed without a complete feature-memory update.",
+);
+console.error(
+  "Touch one specs/<feature-id>/ folder with spec.md, plan.md, and tasks.md in the same PR.",
+);
+
+if (featureCoverage.size > 0) {
+  console.error("Observed feature-memory changes:");
+  for (const [featureId, files] of featureCoverage.entries()) {
+    const touched = Object.entries(files)
+      .filter(([, touchedFlag]) => touchedFlag)
+      .map(([name]) => `${name}.md`)
+      .join(", ");
+    console.error(`- ${featureId}: ${touched || "no complete files"}`);
+  }
+}
+
+process.exit(1);

--- a/scripts/check-static-baseline.mjs
+++ b/scripts/check-static-baseline.mjs
@@ -8,31 +8,51 @@ const root = resolve(process.cwd());
 const requiredFiles = [
   "AGENTS.md",
   "CLAUDE.md",
+  ".specify/memory/constitution.md",
   "index.html",
   "package.json",
   "vercel.json",
   ".gemini/config.yaml",
   ".gemini/styleguide.md",
+  "docs_dreamboard/README.md",
+  "docs_dreamboard/adr/README.md",
   "docs_dreamboard/project-idea.md",
   "docs_dreamboard/project/frontend/frontend-docs.md",
   "docs_dreamboard/project/devops/ai-orchestration-protocol.md",
   "docs_dreamboard/project/devops/ai-runner.md",
+  "docs_dreamboard/project/devops/ai-pr-workflow.md",
+  "docs_dreamboard/project/devops/macos-local-runners.md",
+  "docs_dreamboard/project/devops/delivery-playbook.md",
   "docs_dreamboard/project/devops/review-contract.md",
   "docs_dreamboard/project/devops/vercel-cd.md",
+  "scripts/check-feature-memory.mjs",
+  "scripts/set-implementation-agent.mjs",
+  "scripts/new-worktree.mjs",
+  "scripts/start-implementation-worker.mjs",
+  "scripts/publish-branch.mjs",
   ".github/workflows/ci.yml",
   ".github/workflows/pr-guard.yml",
   ".github/workflows/ai-review.yml",
   ".github/workflows/ai-command-policy.yml",
 ];
 
+const requiredDirs = ["specs"];
+
 const missing = requiredFiles.filter(
   (file) => !existsSync(resolve(root, file)),
 );
 
-if (missing.length > 0) {
+const missingDirs = requiredDirs.filter(
+  (dir) => !existsSync(resolve(root, dir)),
+);
+
+if (missing.length > 0 || missingDirs.length > 0) {
   console.error("Missing required baseline files:");
   for (const file of missing) {
     console.error(`- ${file}`);
+  }
+  for (const dir of missingDirs) {
+    console.error(`- ${dir}/`);
   }
   process.exit(1);
 }

--- a/scripts/new-worktree.mjs
+++ b/scripts/new-worktree.mjs
@@ -12,6 +12,12 @@ const options = {
   base: "origin/main",
 };
 
+const usage = [
+  "Usage:",
+  "  node scripts/new-worktree.mjs --feature <feature-id> [--branch <branch>] [--path <dir>] [--base <ref>]",
+  "  node scripts/new-worktree.mjs --branch <branch> [--path <dir>] [--base <ref>]",
+].join("\n");
+
 for (let index = 0; index < args.length; index += 1) {
   const current = args[index];
 
@@ -33,12 +39,12 @@ for (let index = 0; index < args.length; index += 1) {
       index += 1;
       break;
     default:
-      throw new Error(`Unknown argument: ${current}`);
+      throw new Error(`Unknown argument: ${current}\n\n${usage}`);
   }
 }
 
 if (!options.feature && !options.branch) {
-  throw new Error("Provide --feature or --branch.");
+  throw new Error(`Provide --feature or --branch.\n\n${usage}`);
 }
 
 const run = (command, commandArgs, cwd) =>

--- a/scripts/new-worktree.mjs
+++ b/scripts/new-worktree.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+const options = {
+  feature: "",
+  branch: "",
+  path: "",
+  base: "origin/main",
+};
+
+for (let index = 0; index < args.length; index += 1) {
+  const current = args[index];
+
+  switch (current) {
+    case "--feature":
+      options.feature = (args[index + 1] || "").trim();
+      index += 1;
+      break;
+    case "--branch":
+      options.branch = (args[index + 1] || "").trim();
+      index += 1;
+      break;
+    case "--path":
+      options.path = (args[index + 1] || "").trim();
+      index += 1;
+      break;
+    case "--base":
+      options.base = (args[index + 1] || "").trim() || "origin/main";
+      index += 1;
+      break;
+    default:
+      throw new Error(`Unknown argument: ${current}`);
+  }
+}
+
+if (!options.feature && !options.branch) {
+  throw new Error("Provide --feature or --branch.");
+}
+
+const run = (command, commandArgs, cwd) =>
+  execFileSync(command, commandArgs, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  }).trim();
+
+const repoRoot = run("git", ["rev-parse", "--show-toplevel"], process.cwd());
+const repoParent = dirname(repoRoot);
+const featureSlug = (options.feature || options.branch)
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, "-")
+  .replace(/^-+|-+$/g, "");
+const branch = options.branch || `codex/${featureSlug}`;
+const worktreePath = resolve(
+  repoParent,
+  options.path || `dreamboard-${featureSlug}`,
+);
+
+if (existsSync(worktreePath)) {
+  throw new Error(`Worktree path already exists: ${worktreePath}`);
+}
+
+run("git", ["fetch", "origin", "--prune"], repoRoot);
+
+try {
+  run("git", ["rev-parse", "--verify", branch], repoRoot);
+  throw new Error(`Branch already exists locally: ${branch}`);
+} catch (error) {
+  if (!String(error.message).includes("fatal")) {
+    throw error;
+  }
+}
+
+run(
+  "git",
+  ["worktree", "add", "-b", branch, worktreePath, options.base],
+  repoRoot,
+);
+
+console.log(`Created worktree: ${worktreePath}`);
+console.log(`Branch: ${branch}`);
+console.log("Next steps:");
+console.log(`  cd ${worktreePath}`);
+if (options.feature) {
+  console.log(
+    `  node scripts/start-implementation-worker.mjs --feature ${options.feature} --copy`,
+  );
+}

--- a/scripts/new-worktree.mjs
+++ b/scripts/new-worktree.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
@@ -66,13 +66,13 @@ if (existsSync(worktreePath)) {
 
 run("git", ["fetch", "origin", "--prune"], repoRoot);
 
-try {
-  run("git", ["rev-parse", "--verify", branch], repoRoot);
+const branchLookup = spawnSync("git", ["rev-parse", "--verify", branch], {
+  cwd: repoRoot,
+  stdio: "ignore",
+});
+
+if (branchLookup.status === 0) {
   throw new Error(`Branch already exists locally: ${branch}`);
-} catch (error) {
-  if (!String(error.message).includes("fatal")) {
-    throw error;
-  }
 }
 
 run(

--- a/scripts/new-worktree.mjs
+++ b/scripts/new-worktree.mjs
@@ -70,7 +70,7 @@ if (existsSync(worktreePath)) {
   throw new Error(`Worktree path already exists: ${worktreePath}`);
 }
 
-run("git", ["fetch", "origin", "--prune"], repoRoot);
+run("git", ["fetch", "--all", "--prune"], repoRoot);
 
 const branchLookup = spawnSync("git", ["rev-parse", "--verify", branch], {
   cwd: repoRoot,

--- a/scripts/publish-branch.mjs
+++ b/scripts/publish-branch.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+const options = {
+  feature: "",
+  title: "",
+  body: "",
+  base: "main",
+  repo: "",
+};
+
+for (let index = 0; index < args.length; index += 1) {
+  const current = args[index];
+
+  switch (current) {
+    case "--feature":
+      options.feature = (args[index + 1] || "").trim();
+      index += 1;
+      break;
+    case "--title":
+      options.title = (args[index + 1] || "").trim();
+      index += 1;
+      break;
+    case "--body":
+      options.body = (args[index + 1] || "").trim();
+      index += 1;
+      break;
+    case "--base":
+      options.base = (args[index + 1] || "").trim() || "main";
+      index += 1;
+      break;
+    case "--repo":
+      options.repo = (args[index + 1] || "").trim();
+      index += 1;
+      break;
+    default:
+      throw new Error(`Unknown argument: ${current}`);
+  }
+}
+
+const run = (command, commandArgs, cwd) =>
+  execFileSync(command, commandArgs, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  }).trim();
+
+const repoRoot = run("git", ["rev-parse", "--show-toplevel"], process.cwd());
+const branch = run("git", ["branch", "--show-current"], repoRoot);
+const repoArgs = options.repo ? ["--repo", options.repo] : [];
+
+run("git", ["push", "-u", "origin", branch], repoRoot);
+console.log(`Pushed branch ${branch}.`);
+
+try {
+  const existing = run(
+    "gh",
+    ["pr", "view", "--json", "url,number", ...repoArgs],
+    repoRoot,
+  );
+  const parsed = JSON.parse(existing);
+  console.log(`Existing PR: ${parsed.url}`);
+  process.exit(0);
+} catch {}
+
+const title =
+  options.title ||
+  (options.feature
+    ? `chore: ${options.feature.replace(/^\d+-/, "").replace(/-/g, " ")}`
+    : `chore: update ${branch}`);
+
+const body =
+  options.body ||
+  [
+    "## Summary",
+    `- ${title}`,
+    options.feature ? `- Feature memory: \`specs/${options.feature}/\`` : "",
+    "",
+    "## Validation",
+    "- npm run ci",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+const url = run(
+  "gh",
+  [
+    "pr",
+    "create",
+    "--draft",
+    "--base",
+    options.base,
+    "--head",
+    branch,
+    "--title",
+    title,
+    "--body",
+    body,
+    ...repoArgs,
+  ],
+  repoRoot,
+);
+
+console.log(`Created PR: ${url}`);

--- a/scripts/set-implementation-agent.mjs
+++ b/scripts/set-implementation-agent.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const validImplementationAgents = new Set(["codex", "claude"]);
+const validReviewAgents = new Set(["codex", "claude", "gemini"]);
+
+const args = process.argv.slice(2);
+const options = {
+  implementation: "",
+  review: "",
+  localOnly: false,
+  syncReview: false,
+  repo: "",
+};
+
+for (let index = 0; index < args.length; index += 1) {
+  const current = args[index];
+
+  switch (current) {
+    case "--implementation":
+      options.implementation = (args[index + 1] || "").trim().toLowerCase();
+      index += 1;
+      break;
+    case "--review":
+      options.review = (args[index + 1] || "").trim().toLowerCase();
+      index += 1;
+      break;
+    case "--repo":
+      options.repo = (args[index + 1] || "").trim();
+      index += 1;
+      break;
+    case "--local-only":
+      options.localOnly = true;
+      break;
+    case "--sync-review":
+      options.syncReview = true;
+      break;
+    default:
+      throw new Error(`Unknown argument: ${current}`);
+  }
+}
+
+if (!validImplementationAgents.has(options.implementation)) {
+  throw new Error("--implementation must be one of: codex, claude");
+}
+
+if (!options.review && options.syncReview) {
+  options.review = options.implementation;
+}
+
+if (options.review && !validReviewAgents.has(options.review)) {
+  throw new Error("--review must be one of: codex, claude, gemini");
+}
+
+const run = (command, commandArgs, { cwd, input } = {}) =>
+  execFileSync(command, commandArgs, {
+    cwd,
+    stdio: input ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+    input,
+  }).trim();
+
+const repoRoot = run("git", ["rev-parse", "--show-toplevel"]);
+const codexDir = resolve(repoRoot, ".codex");
+
+if (!existsSync(codexDir)) {
+  mkdirSync(codexDir, { recursive: true });
+}
+
+writeFileSync(
+  resolve(codexDir, "implementation-agent"),
+  `${options.implementation}\n`,
+  "utf8",
+);
+
+if (options.review) {
+  writeFileSync(
+    resolve(codexDir, "review-agent"),
+    `${options.review}\n`,
+    "utf8",
+  );
+}
+
+console.log(`Local implementation agent set to ${options.implementation}.`);
+if (options.review) {
+  console.log(`Local review agent set to ${options.review}.`);
+}
+
+if (options.localOnly) {
+  console.log("Skipped GitHub variable updates because --local-only was used.");
+  process.exit(0);
+}
+
+const baseArgs = options.repo ? ["--repo", options.repo] : [];
+run(
+  "gh",
+  [
+    "variable",
+    "set",
+    "AI_IMPLEMENTATION_AGENT",
+    "--body",
+    options.implementation,
+    ...baseArgs,
+  ],
+  { cwd: repoRoot },
+);
+console.log(
+  `Repository variable AI_IMPLEMENTATION_AGENT set to ${options.implementation}.`,
+);
+
+if (options.review) {
+  run(
+    "gh",
+    [
+      "variable",
+      "set",
+      "AI_REVIEW_AGENT",
+      "--body",
+      options.review,
+      ...baseArgs,
+    ],
+    { cwd: repoRoot },
+  );
+  console.log(`Repository variable AI_REVIEW_AGENT set to ${options.review}.`);
+}

--- a/scripts/start-implementation-worker.mjs
+++ b/scripts/start-implementation-worker.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const args = process.argv.slice(2);
+const options = {
+  feature: "",
+  copy: false,
+};
+
+for (let index = 0; index < args.length; index += 1) {
+  const current = args[index];
+
+  switch (current) {
+    case "--feature":
+      options.feature = (args[index + 1] || "").trim();
+      index += 1;
+      break;
+    case "--copy":
+      options.copy = true;
+      break;
+    default:
+      throw new Error(`Unknown argument: ${current}`);
+  }
+}
+
+if (!options.feature) {
+  throw new Error("--feature is required.");
+}
+
+const run = (command, commandArgs, cwd) =>
+  execFileSync(command, commandArgs, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  }).trim();
+
+const repoRoot = run("git", ["rev-parse", "--show-toplevel"], process.cwd());
+const branch = run("git", ["branch", "--show-current"], repoRoot);
+const codexDir = resolve(repoRoot, ".codex");
+const promptsDir = resolve(codexDir, "prompts");
+const featureDir = resolve(repoRoot, "specs", options.feature);
+
+if (!existsSync(resolve(featureDir, "spec.md"))) {
+  throw new Error(`Missing feature spec folder: ${featureDir}`);
+}
+
+mkdirSync(promptsDir, { recursive: true });
+
+const readLocalState = (name, fallback) => {
+  const file = resolve(codexDir, name);
+  return existsSync(file)
+    ? readFileSync(file, "utf8").trim() || fallback
+    : fallback;
+};
+
+const implementationAgent = readLocalState("implementation-agent", "codex");
+const reviewAgent = readLocalState("review-agent", "gemini");
+
+const prompt = `# dreamboard implementation prompt
+
+Selected implementation agent: ${implementationAgent}
+Selected review backend: ${reviewAgent}
+Current branch: ${branch}
+Active feature folder: specs/${options.feature}/
+
+Read in this order:
+1. .specify/memory/constitution.md
+2. docs_dreamboard/README.md
+3. docs_dreamboard/project/frontend/frontend-docs.md
+4. docs_dreamboard/project/devops/ai-pr-workflow.md
+5. docs_dreamboard/project/devops/macos-local-runners.md
+6. specs/${options.feature}/spec.md
+7. specs/${options.feature}/plan.md
+8. specs/${options.feature}/tasks.md
+
+Execution rules:
+- implement only the scoped task on this branch
+- keep the static site deployable with npm run build
+- update tasks.md as work completes
+- update durable docs when behavior, architecture, or workflow changes
+- do not bypass the PR loop or switch branches
+- prepare the PR for baseline-checks, guard, AI Review, and Vercel preview
+
+Expected handoff:
+- code and docs committed on the same branch
+- concise summary of what changed
+- validation notes with commands run
+- residual risks or follow-ups called out explicitly
+`;
+
+const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+const promptPath = resolve(promptsDir, `${options.feature}-${timestamp}.md`);
+writeFileSync(promptPath, prompt, "utf8");
+
+if (options.copy && process.platform === "darwin") {
+  spawnSync("pbcopy", { input: prompt });
+}
+
+console.log(`Prepared prompt: ${promptPath}`);
+if (options.copy && process.platform === "darwin") {
+  console.log("Prompt copied to the macOS clipboard.");
+}

--- a/specs/001-process-memory-and-macos-runners/plan.md
+++ b/specs/001-process-memory-and-macos-runners/plan.md
@@ -1,0 +1,25 @@
+# Plan
+
+## Slice 1: Repository Memory
+
+- add `.specify/memory/constitution.md`
+- add `docs_dreamboard/README.md`
+- add `docs_dreamboard/adr/README.md`
+- add canonical devops playbooks for PR loop, macOS local runners, and delivery
+
+## Slice 2: Local Orchestration
+
+- add scripts for agent selection, worktree creation, prompt preparation, and
+  PR publishing
+- store local runner state under `.codex/`
+
+## Slice 3: Guardrails
+
+- update baseline checks to require the new memory and orchestration files
+- update `PR Guard` to enforce complete feature memory when product code changes
+
+## Validation
+
+- run `npm run ci`
+- run the new feature-memory validation script locally against the current diff
+- ensure docs and playbooks reflect the actual behavior of the scripts

--- a/specs/001-process-memory-and-macos-runners/spec.md
+++ b/specs/001-process-memory-and-macos-runners/spec.md
@@ -1,0 +1,33 @@
+# Spec: dreamboard process memory and macOS local runners
+
+## Goal
+
+Bring `dreamboard` closer to the structured development model used in
+`flatscanner-demo`, while adapting it to a static Vercel site and local macOS
+worktree orchestration.
+
+## Scope
+
+- add a repository memory layer through `.specify/`, `docs_dreamboard/README`,
+  ADR index, and durable devops playbooks
+- add one active feature-memory folder under `specs/`
+- add macOS-local orchestration scripts for agent selection, worktree creation,
+  prompt preparation, and PR publishing
+- harden repository checks so product changes require feature memory
+
+## Non-Goals
+
+- no framework migration yet
+- no self-hosted GitHub Actions runner
+- no production UI behavior changes in this slice
+- no switch to Claude review until repository secrets are configured
+
+## Acceptance Criteria
+
+1. The repository contains a documented process constitution and docs index.
+2. The repository contains one complete `specs/<feature-id>/` folder for this
+   slice.
+3. macOS-local orchestration scripts exist and are documented.
+4. `baseline-checks` validates the new baseline files.
+5. `guard` fails when product code changes without a complete feature-memory
+   update in the same PR.

--- a/specs/001-process-memory-and-macos-runners/tasks.md
+++ b/specs/001-process-memory-and-macos-runners/tasks.md
@@ -1,0 +1,20 @@
+# Tasks
+
+- [x] Add process-memory files under `.specify/` and `docs_dreamboard/`
+- [x] Add macOS-local orchestration scripts
+- [x] Update agent contracts and devops docs
+- [x] Harden baseline checks and PR guard
+- [x] Run local validation and capture the result in this PR
+
+## Validation
+
+- `npm run ci`
+- `node scripts/check-feature-memory.mjs --worktree`
+- `node scripts/set-implementation-agent.mjs --implementation codex --review gemini --local-only`
+- `node scripts/start-implementation-worker.mjs --feature 001-process-memory-and-macos-runners`
+- `node --check scripts/check-feature-memory.mjs`
+- `node --check scripts/set-implementation-agent.mjs`
+- `node --check scripts/new-worktree.mjs`
+- `node --check scripts/start-implementation-worker.mjs`
+- `node --check scripts/publish-branch.mjs`
+- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); YAML.load_file('.github/workflows/pr-guard.yml')"`


### PR DESCRIPTION
## Summary
- chore: add dreamboard process memory and macOS runner flow
- Feature memory: `specs/001-process-memory-and-macos-runners/`
## Validation
- npm run ci