### PR TITLE
chore: make claude primary orchestrator and move worktrees under .claude/

### DIFF
--- a/.github/workflows/ai-command-policy.yml
+++ b/.github/workflows/ai-command-policy.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           script: |
             const body = (context.payload.comment?.body || "").toLowerCase();
-            const defaults = { implementation: "codex", review: "gemini" };
+            const defaults = { implementation: "claude", review: "codex" };
             const trustedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
             let kind = null;

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -68,7 +68,7 @@ jobs:
           set -euo pipefail
           selected="${{ vars.AI_REVIEW_AGENT }}"
           if [ -z "$selected" ]; then
-            selected="gemini"
+            selected="codex"
           fi
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -93,6 +93,6 @@ jobs:
           AI_REVIEW_PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           AI_REVIEW_TRIGGER_MODE: ${{ steps.policy.outputs.trigger_mode }}
           AI_REVIEW_TRIGGERED_AT: ${{ steps.start.outputs.triggered_at }}
-          AI_REVIEW_WAIT_MS: "900000"
+          AI_REVIEW_WAIT_MS: "1200000"
           AI_REVIEW_POLL_MS: "15000"
         run: node scripts/ai-review-gate.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 .vercel/
 .codex/
+.claude/

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -46,15 +46,18 @@ through Vercel without relying on hidden session memory.
 ## Roles
 
 - User
-  Sets goals, approves product direction, and remains the final merge authority.
-- Codex
-  Owns architecture, orchestration, CI/CD health, repository memory, and can be
-  the selected implementation agent.
+  Sets goals, approves product direction, and remains the final merge
+  authority. Launches implementation loops from a local Claude Code terminal
+  session.
 - Claude
-  Optional implementation or review agent when the repository secret
-  `ANTHROPIC_API_KEY` is configured.
+  Owns architecture, orchestration, CI/CD health, and repository memory, and
+  is the default implementation agent. Runs from the user's local Claude Code
+  terminal session and can dispatch other local agents via CLI when needed.
+- Codex
+  Optional implementation agent and default review backend on GitHub pull
+  requests.
 - Gemini
-  Default native review backend on GitHub.
+  Fallback review backend on GitHub pull requests.
 - GitHub Actions + Vercel
   Execute required checks, review normalization, previews, and production
   deployment.
@@ -76,6 +79,9 @@ through Vercel without relying on hidden session memory.
 
 - Local orchestration is repository-owned and documented in
   `docs_dreamboard/project/devops/macos-local-runners.md`.
-- Local agent selection state is stored under `.codex/` and is gitignored.
+- Local agent selection state is stored under `.claude/` and is gitignored.
+- Local worktrees are created inside `<repoRoot>/.claude/worktrees/<slug>/`
+  so they stay inside the repository and do not pollute the user's
+  `~/projects/` directory.
 - Scripts may prepare prompts, worktrees, and PR publishing, but they must not
   bypass the PR loop or GitHub checks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,15 +62,17 @@ dreamboard/
 - Required GitHub checks are `baseline-checks`, `guard`, and `AI Review`.
 - Vercel handles preview deployments for pull requests and production deployment for `main` through Git integration.
 - Durable workflow docs live under `docs_dreamboard/project/devops/`.
-- Local orchestration state lives under `.codex/` and is gitignored.
+- Local orchestration state lives under `.claude/` and is gitignored.
+- Local worktrees are created inside `<repoRoot>/.claude/worktrees/<slug>/` so they stay inside the repository.
 - Agent selection is policy-driven through repository variables:
   - `AI_IMPLEMENTATION_AGENT`
   - `AI_REVIEW_AGENT`
 - Default policy for this repository is:
-  - implementation: `codex`
-  - review: `gemini`
-- Gemini review is the default because it is installed on the repository and can run natively on GitHub PRs.
-- Claude paths remain available but require `ANTHROPIC_API_KEY` to be configured before switching policy.
+  - implementation: `claude`
+  - review: `codex`
+- Claude is the default implementation agent because it owns architecture, orchestration, CI/CD health, and repository memory, and is driven from the user's local Claude Code terminal session.
+- Codex is the default review backend because it runs natively on GitHub pull requests and emits `P0`–`P3` inline severity markers.
+- Gemini stays available as the fallback review backend when `AI_REVIEW_AGENT=gemini`. Claude review is a third-tier option behind an explicit `AI_REVIEW_AGENT=claude` override and still requires `ANTHROPIC_API_KEY` when used.
 - Trusted human review commands still follow the shared `AI Review` contract, but only `claude` uses `workflow_dispatch`; `gemini` and `codex` stay native-only so they do not cancel the PR-linked gate.
 - Only trusted repository actors may trigger AI workflows.
 - Trusted actors are `OWNER`, `MEMBER`, and `COLLABORATOR`.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ dreamboard/
   runs in its own worktree / branch / PR.
 - Required checks: `baseline-checks`, `guard`, `AI Review`.
 - Agent policy is repository-driven via `AI_IMPLEMENTATION_AGENT` and
-  `AI_REVIEW_AGENT` (defaults: `codex` for implementation, `gemini` for review).
+  `AI_REVIEW_AGENT` (defaults: `claude` for implementation, `codex` for
+  review, with `gemini` as the fallback review backend).
 
 See [`AGENTS.md`](./AGENTS.md) for the full onboarding route and
 [`docs_dreamboard/README.md`](./docs_dreamboard/README.md) for the durable docs

--- a/docs_dreamboard/project/devops/ai-orchestration-protocol.md
+++ b/docs_dreamboard/project/devops/ai-orchestration-protocol.md
@@ -23,18 +23,26 @@ Agent routing is controlled by repository variables:
 
 ## Supported Agents
 
-- `codex`
 - `claude`
+- `codex`
 - `gemini`
 
 Default policy in this repository:
 
-- implementation: `codex`
-- review: `gemini`
+- implementation: `claude`
+- review: `codex`
 
-Gemini is the canonical default review backend for this repository because it is already installed on GitHub and runs natively on pull requests.
+Claude is the canonical default implementation agent because it owns
+architecture, orchestration, CI/CD health, and repository memory for this
+repository, and is driven from the user's local Claude Code terminal session.
 
-Claude remains supported as an optional backend when `ANTHROPIC_API_KEY` is configured and the repository variable is switched.
+Codex is the canonical default review backend because it runs natively on
+GitHub pull requests and emits `P0`–`P3` inline severity markers.
+
+Gemini stays available as the fallback review backend when
+`AI_REVIEW_AGENT=gemini` is set. Claude review is a third-tier option behind
+an explicit `AI_REVIEW_AGENT=claude` override and still requires
+`ANTHROPIC_API_KEY` when used.
 
 ## Local macOS Orchestration
 
@@ -45,27 +53,32 @@ Implementation work is prepared locally through repository-owned macOS helpers:
 - `scripts/start-implementation-worker.mjs`
 - `scripts/publish-branch.mjs`
 
-One task should map to one worktree, one branch, and one PR.
+One task should map to one worktree, one branch, and one PR. Worktrees are
+created inside `<repoRoot>/.claude/worktrees/<slug>/` so they stay inside the
+repository and do not pollute the user's `~/projects/` directory.
 
 ## Native Execution Surface
 
-- Codex implementation: start the task from Codex app or Codex web against the repository branch
-- Codex review: `@codex review` on a top-level PR comment
-- Claude implementation: `@claude <task brief>` on a trusted issue/PR comment
-- Claude review: `@claude review once` on a top-level PR comment
-- Gemini review: `/gemini review` on a top-level PR comment
+- Claude implementation: launched from a local Claude Code terminal session
+  against the feature worktree; can dispatch other local agents via CLI when
+  needed
+- Codex implementation: started from Codex app or Codex web against the
+  repository branch (optional)
+- Codex review: native GitHub PR review from `chatgpt-codex-connector[bot]`
+- Gemini review: `/gemini review` on a top-level PR comment (fallback)
+- Claude review: `@claude review once` on a top-level PR comment (third-tier)
 
 Review normalization behavior:
 
-- `gemini` is the default automatic pull-request reviewer
-- pull-request `AI Review` runs support both `gemini` and `codex`; `codex`
-  uses passive same-head detection on PR events instead of a bot-authored
-  trigger comment
+- `codex` is the default automatic pull-request reviewer and uses passive
+  same-head detection on PR events instead of a bot-authored trigger comment
+- pull-request `AI Review` runs support both `codex` and `gemini`
+- manual Gemini and Codex review comments stay native-only to avoid canceling
+  the PR-linked `AI Review` check
 - trusted human review commands dispatch the shared `AI Review` gate via
   `workflow_dispatch` only for `claude`
-- manual Gemini and Codex comments stay native-only to avoid canceling the
-  PR-linked `AI Review` check
-- the gate may reuse an existing same-head native review when a PR-linked `AI Review` run is rerun
+- the gate may reuse an existing same-head native review when a PR-linked
+  `AI Review` run is rerun
 
 Only trusted actors may trigger AI workflows:
 

--- a/docs_dreamboard/project/devops/ai-pr-workflow.md
+++ b/docs_dreamboard/project/devops/ai-pr-workflow.md
@@ -4,8 +4,8 @@ This is the canonical PR loop for `dreamboard`.
 
 ## Roles
 
-- Codex owns architecture, repository memory, CI/CD health, and local
-  orchestration.
+- Claude owns architecture, repository memory, CI/CD health, and local
+  orchestration, and is the default implementation agent.
 - The selected implementation agent writes scoped code on a feature branch.
 - GitHub Actions runs `baseline-checks`, `guard`, and `AI Review`.
 - Vercel provides preview deployments for PRs and production deploy on merge to
@@ -16,7 +16,8 @@ This is the canonical PR loop for `dreamboard`.
 
 1. Start from current `main`.
 2. Create or update one active `specs/<feature-id>/` folder.
-3. Create an isolated macOS worktree for the task.
+3. Create an isolated macOS worktree for the task under
+   `<repoRoot>/.claude/worktrees/<slug>/`.
 4. Select the implementation and review agents for the branch.
 5. Generate the implementation prompt from repository memory.
 6. Implement only the scoped change on that branch.
@@ -41,15 +42,18 @@ This is the canonical PR loop for `dreamboard`.
 ## Review Contract
 
 - Reviewer selection comes only from `AI_REVIEW_AGENT`.
-- Supported review backends are `gemini`, `codex`, and `claude`.
+- Supported review backends are `codex`, `gemini`, and `claude`.
 - `AI Review` is the normalized required check regardless of the backend.
 - Low-severity-only findings are advisory and non-blocking.
-- With no repository override, the pull-request gate defaults to `gemini`.
-- When `AI_REVIEW_AGENT=codex`, the pull-request gate waits for native Codex output without posting a bot-authored `@codex review` trigger comment.
+- With no repository override, the pull-request gate defaults to `codex` and
+  uses passive same-head detection instead of posting a bot-authored trigger
+  comment.
+- When `AI_REVIEW_AGENT=gemini`, the pull-request gate posts a single
+  bot-authored `/gemini review` trigger comment for the current PR head.
 - Manual Gemini and Codex review commands stay native-only so they do not
   cancel the PR-linked `AI Review` check.
 - Rerunning the PR-linked `AI Review` workflow is enough to reuse same-head
-  Gemini output.
+  Codex or Gemini output.
 
 ## Merge-Ready Definition
 

--- a/docs_dreamboard/project/devops/ai-runner.md
+++ b/docs_dreamboard/project/devops/ai-runner.md
@@ -9,49 +9,61 @@ The orchestration layer reads:
 
 If a variable is unset, the workflows fall back to repository defaults:
 
-- implementation: `codex`
-- review: `gemini`
+- implementation: `claude`
+- review: `codex`
 
 Local macOS helper scripts may also store the current selection under:
 
-- `.codex/implementation-agent`
-- `.codex/review-agent`
+- `.claude/implementation-agent`
+- `.claude/review-agent`
 
-## Claude Requirements
+## Backend Requirements
 
-Claude paths require repository secret:
+- `claude` is the default implementation agent. The user runs it from a local
+  Claude Code terminal session, and no additional GitHub secret is required
+  for the default implementation path. When `claude` is used as a third-tier
+  review backend through the `@claude` GitHub app, `ANTHROPIC_API_KEY` must be
+  configured in repository secrets.
+- `codex` is the default review backend and the optional implementation
+  backend. Native Codex PR review needs no repository secret; Codex
+  implementation requires the Codex app or Codex CLI to be available locally
+  when you hand off the prepared prompt.
+- `gemini` is the fallback review backend and runs natively on GitHub pull
+  requests without additional setup.
 
-- `ANTHROPIC_API_KEY`
-
-If the secret is missing and Claude is selected, the workflow fails closed with an explanatory comment instead of silently skipping.
+If a selected backend is missing its requirements, the workflow fails closed
+with an explanatory comment instead of silently skipping.
 
 ## Review Gate
 
 `AI Review` is a normalization layer on top of native vendor review outputs.
 
-- Codex path waits for native GitHub PR review output from `chatgpt-codex-connector[bot]`
+- Codex path waits for native GitHub PR review output from
+  `chatgpt-codex-connector[bot]` (default).
+- Gemini path waits for native GitHub PR review output from
+  `gemini-code-assist[bot]` and classifies inline review comments by
+  `Critical`, `High`, `Medium`, and `Low` severity markers.
 - Claude path waits for a top-level `claude[bot]` comment containing:
   - `AI_REVIEW_AGENT: claude`
   - `AI_REVIEW_SHA: <head sha>`
   - `AI_REVIEW_OUTCOME: pass|advisory|block`
-- Gemini path waits for native GitHub PR review output from `gemini-code-assist[bot]` and classifies inline review comments by `Critical`, `High`, `Medium`, and `Low` severity markers.
 
 The gate passes on:
 
 - Codex approval
 - Codex advisory-only review
-- Claude `pass`
-- Claude `advisory`
 - Gemini approval
 - Gemini advisory-only review
+- Claude `pass`
+- Claude `advisory`
 
 The gate fails on:
 
 - Codex `CHANGES_REQUESTED`
 - Codex inline findings with highest severity `P0`, `P1`, or `P2`
-- Claude `block`
 - Gemini `CHANGES_REQUESTED`
 - Gemini inline findings with highest severity `Critical`, `High`, or `Medium`
+- Claude `block`
 - setup/runtime failures for the selected backend
 
 ## Feature Memory Gate

--- a/docs_dreamboard/project/devops/macos-local-runners.md
+++ b/docs_dreamboard/project/devops/macos-local-runners.md
@@ -18,6 +18,9 @@ macOS helpers for:
 - One task equals one worktree, one branch, and one PR.
 - Never run multiple implementation loops inside the main checkout.
 - Start each worktree from current `main`.
+- Keep worktrees inside the repository at
+  `<repoRoot>/.claude/worktrees/<slug>/` so they do not pollute the user's
+  `~/projects/` directory.
 - Keep prompts tied to one active `specs/<feature-id>/` folder.
 - Use the scripts to prepare and publish work, but never bypass GitHub checks.
 
@@ -25,16 +28,18 @@ macOS helpers for:
 
 - macOS with `git`, `gh`, and Node.js 24 available
 - authenticated GitHub CLI for repository variable updates and PR creation
-- Codex app or Claude Code available locally when you want to hand off the
-  prepared prompt
+- Claude Code available locally as the primary implementation agent
+- Codex app or Codex CLI available locally only when you want to hand off the
+  prepared prompt to Codex as the optional implementation agent
 
 ## Local State
 
-The scripts keep local orchestration state in `.codex/`:
+The scripts keep local orchestration state in `.claude/`:
 
-- `.codex/implementation-agent`
-- `.codex/review-agent`
-- `.codex/prompts/`
+- `.claude/implementation-agent`
+- `.claude/review-agent`
+- `.claude/prompts/`
+- `.claude/worktrees/`
 
 This directory is local-only and gitignored.
 
@@ -43,13 +48,13 @@ This directory is local-only and gitignored.
 1. Select policy.
 
 ```bash
-node scripts/set-implementation-agent.mjs --implementation codex --review gemini
+node scripts/set-implementation-agent.mjs --implementation claude --review codex
 ```
 
-2. Create a new isolated worktree.
+2. Create a new isolated worktree inside `.claude/worktrees/`.
 
 ```bash
-node scripts/new-worktree.mjs --feature 001-process-memory-and-macos-runners
+node scripts/new-worktree.mjs --feature 004-claude-primary-orchestrator
 ```
 
 3. Change into the created worktree.
@@ -58,7 +63,7 @@ node scripts/new-worktree.mjs --feature 001-process-memory-and-macos-runners
 
 ```bash
 node scripts/start-implementation-worker.mjs \
-  --feature 001-process-memory-and-macos-runners \
+  --feature 004-claude-primary-orchestrator \
   --copy
 ```
 
@@ -68,13 +73,14 @@ node scripts/start-implementation-worker.mjs \
 
 ```bash
 node scripts/publish-branch.mjs \
-  --feature 001-process-memory-and-macos-runners \
-  --title "chore: add dreamboard process memory and macOS local runner flow"
+  --feature 004-claude-primary-orchestrator \
+  --title "chore: swap claude and codex roles and move worktrees inside repo"
 ```
 
 ## Trade-Offs
 
 - The repository prepares prompts and branch/worktree state, but it does not
   force-launch a specific local app.
-- Claude review remains unavailable until `ANTHROPIC_API_KEY` is configured in
-  GitHub repository secrets.
+- Codex implementation and Claude review remain optional paths behind an
+  explicit `AI_IMPLEMENTATION_AGENT=codex` or `AI_REVIEW_AGENT=claude`
+  override.

--- a/docs_dreamboard/project/devops/review-contract.md
+++ b/docs_dreamboard/project/devops/review-contract.md
@@ -2,13 +2,15 @@
 
 ## Codex Review
 
-- Native GitHub PR review surface
+- Default review backend for `dreamboard`
+- Native GitHub PR review surface from `chatgpt-codex-connector[bot]`
 - Inline findings must carry `P0` to `P3`
 - `P3`-only findings are advisory
 - `P0` to `P2` findings block merge
 
 ## Gemini Review
 
+- Fallback review backend, used when `AI_REVIEW_AGENT=gemini`
 - Native GitHub PR review surface from `gemini-code-assist[bot]`
 - Inline findings are expected to carry `Critical`, `High`, `Medium`, or `Low`
 - `Low`-only findings are advisory
@@ -16,6 +18,7 @@
 
 ## Claude Review
 
+- Third-tier review backend, used only when `AI_REVIEW_AGENT=claude`
 - Final result is a top-level comment, not a formal GitHub review state
 - The comment must start with:
 

--- a/scripts/new-worktree.mjs
+++ b/scripts/new-worktree.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
 
 const args = process.argv.slice(2);
 const options = {
@@ -55,20 +55,21 @@ const run = (command, commandArgs, cwd) =>
   }).trim();
 
 const repoRoot = run("git", ["rev-parse", "--show-toplevel"], process.cwd());
-const repoParent = dirname(repoRoot);
 const featureSlug = (options.feature || options.branch)
   .toLowerCase()
   .replace(/[^a-z0-9]+/g, "-")
   .replace(/^-+|-+$/g, "");
-const branch = options.branch || `codex/${featureSlug}`;
-const worktreePath = resolve(
-  repoParent,
-  options.path || `dreamboard-${featureSlug}`,
-);
+const branch = options.branch || `claude/${featureSlug}`;
+const worktreesRoot = resolve(repoRoot, ".claude", "worktrees");
+const worktreePath = options.path
+  ? resolve(repoRoot, options.path)
+  : resolve(worktreesRoot, featureSlug);
 
 if (existsSync(worktreePath)) {
   throw new Error(`Worktree path already exists: ${worktreePath}`);
 }
+
+mkdirSync(worktreesRoot, { recursive: true });
 
 run("git", ["fetch", "--all", "--prune"], repoRoot);
 

--- a/scripts/new-worktree.mjs
+++ b/scripts/new-worktree.mjs
@@ -2,7 +2,7 @@
 
 import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 
 const args = process.argv.slice(2);
 const options = {
@@ -54,7 +54,12 @@ const run = (command, commandArgs, cwd) =>
     encoding: "utf8",
   }).trim();
 
-const repoRoot = run("git", ["rev-parse", "--show-toplevel"], process.cwd());
+const gitCommonDir = run(
+  "git",
+  ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+  process.cwd(),
+);
+const repoRoot = dirname(gitCommonDir);
 const featureSlug = (options.feature || options.branch)
   .toLowerCase()
   .replace(/[^a-z0-9]+/g, "-")

--- a/scripts/set-implementation-agent.mjs
+++ b/scripts/set-implementation-agent.mjs
@@ -2,7 +2,7 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 
 const validImplementationAgents = new Set(["codex", "claude"]);
 const validReviewAgents = new Set(["codex", "claude", "gemini"]);
@@ -63,7 +63,12 @@ const run = (command, commandArgs, { cwd, input } = {}) =>
     input,
   }).trim();
 
-const repoRoot = run("git", ["rev-parse", "--show-toplevel"]);
+const gitCommonDir = run("git", [
+  "rev-parse",
+  "--path-format=absolute",
+  "--git-common-dir",
+]);
+const repoRoot = dirname(gitCommonDir);
 const claudeDir = resolve(repoRoot, ".claude");
 
 if (!existsSync(claudeDir)) {

--- a/scripts/set-implementation-agent.mjs
+++ b/scripts/set-implementation-agent.mjs
@@ -2,7 +2,7 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { resolve } from "node:path";
 
 const validImplementationAgents = new Set(["codex", "claude"]);
 const validReviewAgents = new Set(["codex", "claude", "gemini"]);
@@ -63,12 +63,7 @@ const run = (command, commandArgs, { cwd, input } = {}) =>
     input,
   }).trim();
 
-const gitCommonDir = run("git", [
-  "rev-parse",
-  "--path-format=absolute",
-  "--git-common-dir",
-]);
-const repoRoot = dirname(gitCommonDir);
+const repoRoot = run("git", ["rev-parse", "--show-toplevel"]);
 const claudeDir = resolve(repoRoot, ".claude");
 
 if (!existsSync(claudeDir)) {

--- a/scripts/set-implementation-agent.mjs
+++ b/scripts/set-implementation-agent.mjs
@@ -64,21 +64,21 @@ const run = (command, commandArgs, { cwd, input } = {}) =>
   }).trim();
 
 const repoRoot = run("git", ["rev-parse", "--show-toplevel"]);
-const codexDir = resolve(repoRoot, ".codex");
+const claudeDir = resolve(repoRoot, ".claude");
 
-if (!existsSync(codexDir)) {
-  mkdirSync(codexDir, { recursive: true });
+if (!existsSync(claudeDir)) {
+  mkdirSync(claudeDir, { recursive: true });
 }
 
 writeFileSync(
-  resolve(codexDir, "implementation-agent"),
+  resolve(claudeDir, "implementation-agent"),
   `${options.implementation}\n`,
   "utf8",
 );
 
 if (options.review) {
   writeFileSync(
-    resolve(codexDir, "review-agent"),
+    resolve(claudeDir, "review-agent"),
     `${options.review}\n`,
     "utf8",
   );

--- a/scripts/set-implementation-agent.mjs
+++ b/scripts/set-implementation-agent.mjs
@@ -2,7 +2,7 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 
 const validImplementationAgents = new Set(["codex", "claude"]);
 const validReviewAgents = new Set(["codex", "claude", "gemini"]);
@@ -63,7 +63,15 @@ const run = (command, commandArgs, { cwd, input } = {}) =>
     input,
   }).trim();
 
-const repoRoot = run("git", ["rev-parse", "--show-toplevel"]);
+// Store agent policy at the primary repo root so every linked worktree
+// observes the same selection. The GitHub repo variables updated below
+// are the canonical source of truth; this local file is a shared cache.
+const gitCommonDir = run("git", [
+  "rev-parse",
+  "--path-format=absolute",
+  "--git-common-dir",
+]);
+const repoRoot = dirname(gitCommonDir);
 const claudeDir = resolve(repoRoot, ".claude");
 
 if (!existsSync(claudeDir)) {

--- a/scripts/start-implementation-worker.mjs
+++ b/scripts/start-implementation-worker.mjs
@@ -2,7 +2,7 @@
 
 import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 
 const args = process.argv.slice(2);
 const options = {
@@ -37,12 +37,24 @@ const run = (command, commandArgs, cwd) =>
     encoding: "utf8",
   }).trim();
 
-const repoRoot = run("git", ["rev-parse", "--show-toplevel"], process.cwd());
-const branch = run("git", ["branch", "--show-current"], repoRoot);
-const claudeDir = resolve(repoRoot, ".claude");
-const legacyCodexDir = resolve(repoRoot, ".codex");
+// Split repo roots by data semantics:
+// - `primaryRoot` for shared state under `.claude/` (agent selection,
+//   prompts, legacy `.codex/` fallback) so every linked worktree reads
+//   the same selection written by scripts/set-implementation-agent.mjs.
+// - `workingRoot` for per-branch files like `specs/<feature>/` that live
+//   in the checkout of the current worktree's branch.
+const workingRoot = run("git", ["rev-parse", "--show-toplevel"], process.cwd());
+const gitCommonDir = run(
+  "git",
+  ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+  process.cwd(),
+);
+const primaryRoot = dirname(gitCommonDir);
+const branch = run("git", ["branch", "--show-current"], workingRoot);
+const claudeDir = resolve(primaryRoot, ".claude");
+const legacyCodexDir = resolve(primaryRoot, ".codex");
 const promptsDir = resolve(claudeDir, "prompts");
-const featureDir = resolve(repoRoot, "specs", options.feature);
+const featureDir = resolve(workingRoot, "specs", options.feature);
 
 if (!existsSync(resolve(featureDir, "spec.md"))) {
   throw new Error(`Missing feature spec folder: ${featureDir}`);

--- a/scripts/start-implementation-worker.mjs
+++ b/scripts/start-implementation-worker.mjs
@@ -39,8 +39,9 @@ const run = (command, commandArgs, cwd) =>
 
 const repoRoot = run("git", ["rev-parse", "--show-toplevel"], process.cwd());
 const branch = run("git", ["branch", "--show-current"], repoRoot);
-const codexDir = resolve(repoRoot, ".codex");
-const promptsDir = resolve(codexDir, "prompts");
+const claudeDir = resolve(repoRoot, ".claude");
+const legacyCodexDir = resolve(repoRoot, ".codex");
+const promptsDir = resolve(claudeDir, "prompts");
 const featureDir = resolve(repoRoot, "specs", options.feature);
 
 if (!existsSync(resolve(featureDir, "spec.md"))) {
@@ -50,14 +51,22 @@ if (!existsSync(resolve(featureDir, "spec.md"))) {
 mkdirSync(promptsDir, { recursive: true });
 
 const readLocalState = (name, fallback) => {
-  const file = resolve(codexDir, name);
-  return existsSync(file)
-    ? readFileSync(file, "utf8").trim() || fallback
-    : fallback;
+  const file = resolve(claudeDir, name);
+  if (existsSync(file)) {
+    return readFileSync(file, "utf8").trim() || fallback;
+  }
+  const legacyFile = resolve(legacyCodexDir, name);
+  if (existsSync(legacyFile)) {
+    console.warn(
+      `warning: reading legacy ${legacyFile}; run scripts/set-implementation-agent.mjs to migrate to .claude/`,
+    );
+    return readFileSync(legacyFile, "utf8").trim() || fallback;
+  }
+  return fallback;
 };
 
-const implementationAgent = readLocalState("implementation-agent", "codex");
-const reviewAgent = readLocalState("review-agent", "gemini");
+const implementationAgent = readLocalState("implementation-agent", "claude");
+const reviewAgent = readLocalState("review-agent", "codex");
 
 const prompt = `# dreamboard implementation prompt
 

--- a/scripts/start-implementation-worker.mjs
+++ b/scripts/start-implementation-worker.mjs
@@ -2,7 +2,7 @@
 
 import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { resolve } from "node:path";
 
 const args = process.argv.slice(2);
 const options = {
@@ -37,13 +37,8 @@ const run = (command, commandArgs, cwd) =>
     encoding: "utf8",
   }).trim();
 
-const gitCommonDir = run(
-  "git",
-  ["rev-parse", "--path-format=absolute", "--git-common-dir"],
-  process.cwd(),
-);
-const repoRoot = dirname(gitCommonDir);
-const branch = run("git", ["branch", "--show-current"], process.cwd());
+const repoRoot = run("git", ["rev-parse", "--show-toplevel"], process.cwd());
+const branch = run("git", ["branch", "--show-current"], repoRoot);
 const claudeDir = resolve(repoRoot, ".claude");
 const legacyCodexDir = resolve(repoRoot, ".codex");
 const promptsDir = resolve(claudeDir, "prompts");

--- a/scripts/start-implementation-worker.mjs
+++ b/scripts/start-implementation-worker.mjs
@@ -2,7 +2,7 @@
 
 import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 
 const args = process.argv.slice(2);
 const options = {
@@ -37,8 +37,13 @@ const run = (command, commandArgs, cwd) =>
     encoding: "utf8",
   }).trim();
 
-const repoRoot = run("git", ["rev-parse", "--show-toplevel"], process.cwd());
-const branch = run("git", ["branch", "--show-current"], repoRoot);
+const gitCommonDir = run(
+  "git",
+  ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+  process.cwd(),
+);
+const repoRoot = dirname(gitCommonDir);
+const branch = run("git", ["branch", "--show-current"], process.cwd());
 const claudeDir = resolve(repoRoot, ".claude");
 const legacyCodexDir = resolve(repoRoot, ".codex");
 const promptsDir = resolve(claudeDir, "prompts");

--- a/specs/004-claude-primary-orchestrator/plan.md
+++ b/specs/004-claude-primary-orchestrator/plan.md
@@ -1,0 +1,52 @@
+# Plan
+
+## Slice 1: Documentation swap (this PR, phase 1)
+
+- rewrite role definitions and default policy in the six devops docs plus
+  `.specify/memory/constitution.md`, `AGENTS.md`, and `README.md`
+- reorder `docs_dreamboard/project/devops/review-contract.md` sections so
+  Codex comes first, Gemini second, Claude third
+- update `.gitignore` to cover `.claude/`
+- update the user auto-memory note `feedback_worktree_location.md` to record
+  that this spec is where the worktree location fix is tracked
+
+## Slice 2: Worktree location fix (phase 2)
+
+- rewrite `scripts/new-worktree.mjs` so the worktree path is computed as
+  `resolve(repoRoot, '.claude/worktrees', slug)` instead of
+  `resolve(dirname(repoRoot), options.path || `dreamboard-${slug}`)`
+- change the default branch prefix from `codex/<slug>` to `claude/<slug>`
+  when `--branch` is not supplied
+- ensure `.claude/worktrees/` is created on demand and that existing entries
+  are detected with a clear error message
+- keep `--path` as an explicit override for unusual cases
+
+## Slice 3: Local state rename (phase 2)
+
+- `scripts/set-implementation-agent.mjs`,
+  `scripts/start-implementation-worker.mjs`, and `scripts/publish-branch.mjs`
+  read and write `.claude/implementation-agent`, `.claude/review-agent`, and
+  `.claude/prompts/` instead of the `.codex/...` paths
+- if a legacy `.codex/implementation-agent` or `.codex/review-agent` file
+  exists, print a one-line deprecation notice and migrate on first run
+- remove `.codex/` from `.gitignore` only once the scripts stop writing to it
+
+## Slice 4: GitHub workflow defaults (phase 2)
+
+- any `.github/workflows/*.yml` step that hard-codes a fallback default for
+  `AI_IMPLEMENTATION_AGENT` or `AI_REVIEW_AGENT` updates from `codex`/`gemini`
+  to `claude`/`codex`
+- no rename of the `AI Review` job, its required check name, or its header
+  schema
+- trusted human review commands still only use `workflow_dispatch` for
+  `claude`; `codex` and `gemini` stay native-only
+
+## Slice 5: Validation
+
+- `pnpm run ci` inside the worktree
+- `node scripts/check-feature-memory.mjs --worktree`
+- manual smoke check: `node scripts/new-worktree.mjs --feature 999-test-path`
+  creates the worktree under `<repoRoot>/.claude/worktrees/999-test-path/`
+  and leaves `~/projects/` untouched
+- green required checks on the PR head SHA
+- healthy Vercel preview for the unchanged editor and landing flows

--- a/specs/004-claude-primary-orchestrator/spec.md
+++ b/specs/004-claude-primary-orchestrator/spec.md
@@ -1,0 +1,89 @@
+# Spec: swap Claude ↔ Codex roles and move worktrees inside the repo
+
+## Goal
+
+Make Claude Code the primary orchestrator (architecture, orchestration, CI/CD
+health, repository memory) and the default implementation agent for
+`dreamboard`. Move Codex to the optional implementation slot and make it the
+default review backend on GitHub PRs. Keep Gemini as the fallback review
+backend and Claude review as a third-tier option. Fix the worktree location bug
+so local worktrees live inside `.claude/worktrees/` instead of
+`~/projects/dreamboard-<slug>/`.
+
+## Scope
+
+- rewrite role definitions and default policy in:
+  - `.specify/memory/constitution.md`
+  - `docs_dreamboard/project/devops/ai-orchestration-protocol.md`
+  - `docs_dreamboard/project/devops/ai-pr-workflow.md`
+  - `docs_dreamboard/project/devops/ai-runner.md`
+  - `docs_dreamboard/project/devops/macos-local-runners.md`
+  - `docs_dreamboard/project/devops/review-contract.md`
+  - `AGENTS.md`
+  - `README.md`
+- reorder `review-contract.md` so Codex comes first, Gemini second, Claude
+  third
+- rename local orchestration state directory from `.codex/` to `.claude/`
+  across the affected docs and (in phase 2) the helper scripts
+- change `scripts/new-worktree.mjs` so new worktrees are created inside the
+  repository at `<repoRoot>/.claude/worktrees/<slug>/` and use `claude/<slug>`
+  as the default branch prefix
+- update `scripts/set-implementation-agent.mjs`,
+  `scripts/start-implementation-worker.mjs`, and `scripts/publish-branch.mjs`
+  readers to use `.claude/implementation-agent`, `.claude/review-agent`, and
+  `.claude/prompts/`
+- update `.github/workflows/*.yml` fallback defaults where the implementation
+  and review backend names are hard-coded to move from `codex`/`gemini` to
+  `claude`/`codex`
+- update `.gitignore` to cover `.claude/`
+- update user auto-memory `feedback_worktree_location.md` to record that the
+  fix is tracked in this spec
+
+## Non-Goals
+
+- no changes to application behavior in `index.html` or `src/`
+- no changes to Vercel configuration or Vercel dashboard settings
+- no changes to the required check names (`baseline-checks`, `guard`,
+  `AI Review`) or to the `AI_REVIEW_AGENT` / `AI_REVIEW_SHA` /
+  `AI_REVIEW_OUTCOME` header schema
+- no removal of Codex or Gemini support — only a reordering of defaults
+- no new external dependencies
+- no rename of repository variables or secrets
+
+## Acceptance Criteria
+
+1. `.specify/memory/constitution.md` §Roles names Claude as the owner of
+   architecture, orchestration, CI/CD health, repository memory, and as the
+   default implementation agent, with Codex optional and Gemini as the
+   fallback review backend.
+2. `docs_dreamboard/project/devops/ai-orchestration-protocol.md` declares
+   default policy `implementation: claude`, `review: codex`, with Gemini as
+   fallback and Claude as a third-tier review option.
+3. `docs_dreamboard/project/devops/ai-pr-workflow.md` attributes orchestration
+   ownership to Claude and sets the pull-request gate default to Codex.
+4. `docs_dreamboard/project/devops/ai-runner.md` uses `.claude/` for local
+   state paths and documents Codex as the default review backend plus the
+   optional implementation backend.
+5. `docs_dreamboard/project/devops/macos-local-runners.md` lists Claude Code as
+   the primary prerequisite, `.claude/` for local state, the example command
+   as `--implementation claude --review codex`, and shows worktrees being
+   created inside `<repoRoot>/.claude/worktrees/<slug>/`.
+6. `docs_dreamboard/project/devops/review-contract.md` orders review backend
+   sections as Codex → Gemini → Claude and marks Claude as a third-tier option.
+7. `AGENTS.md` and `README.md` state the new defaults (`claude` for
+   implementation, `codex` for review, `gemini` as fallback).
+8. `.gitignore` ignores `.claude/` in addition to the existing `.codex/`
+   entry.
+9. `scripts/new-worktree.mjs` creates new worktrees at
+   `<repoRoot>/.claude/worktrees/<slug>/` and uses `claude/<slug>` as the
+   default branch prefix when `--branch` is not supplied.
+10. `scripts/set-implementation-agent.mjs`,
+    `scripts/start-implementation-worker.mjs`, and `scripts/publish-branch.mjs`
+    read and write `.claude/implementation-agent`, `.claude/review-agent`, and
+    `.claude/prompts/` instead of the `.codex/...` paths.
+11. Any hard-coded fallback default for `AI_IMPLEMENTATION_AGENT` or
+    `AI_REVIEW_AGENT` inside `.github/workflows/*.yml` resolves to `claude` /
+    `codex`.
+12. On the PR head SHA for this feature, `baseline-checks`, `guard`,
+    `AI Review`, and the Vercel preview are all green, and
+    `node scripts/check-feature-memory.mjs --worktree` passes.

--- a/specs/004-claude-primary-orchestrator/tasks.md
+++ b/specs/004-claude-primary-orchestrator/tasks.md
@@ -1,0 +1,30 @@
+# Tasks
+
+## Phase 1 — Documentation (this PR)
+
+- [x] Update `.specify/memory/constitution.md` §Roles and §macOS Local Runner Contract
+- [x] Rewrite `docs_dreamboard/project/devops/ai-orchestration-protocol.md` defaults and execution surface order
+- [x] Rewrite `docs_dreamboard/project/devops/ai-pr-workflow.md` orchestration ownership and gate default
+- [x] Rewrite `docs_dreamboard/project/devops/ai-runner.md` local state paths and backend requirements
+- [x] Rewrite `docs_dreamboard/project/devops/macos-local-runners.md` prerequisites, local state, example command, and worktree path
+- [x] Reorder `docs_dreamboard/project/devops/review-contract.md` sections (Codex → Gemini → Claude)
+- [x] Update `AGENTS.md` onboarding defaults and review guidelines
+- [x] Update `README.md` workflow defaults line
+- [x] Add `.claude/` entry to `.gitignore`
+- [x] Update `feedback_worktree_location.md` auto-memory with reference to this spec
+
+## Phase 2 — Implementation (follow-up slice in the same PR or a follow-up PR)
+
+- [x] Rewrite `scripts/new-worktree.mjs` to target `<repoRoot>/.claude/worktrees/<slug>/` and `claude/<slug>` as the default branch prefix
+- [x] Rename `.codex/` local state to `.claude/` in `scripts/set-implementation-agent.mjs` and `scripts/start-implementation-worker.mjs` (`publish-branch.mjs` does not read that state)
+- [x] Print a deprecation notice in `scripts/start-implementation-worker.mjs` when legacy `.codex/` state is detected
+- [x] Update `.github/workflows/ai-review.yml` and `.github/workflows/ai-command-policy.yml` fallback defaults from `codex`/`gemini` to `claude`/`codex`
+- [ ] Run `pnpm run ci` and paste the result in this PR
+- [ ] Run `node scripts/check-feature-memory.mjs --worktree` and paste the result in this PR
+- [ ] Open or update the PR and wait for `baseline-checks`, `guard`, `AI Review`, and Vercel preview to be green on the same head SHA
+
+## Validation
+
+- `pnpm run ci`
+- `node scripts/check-feature-memory.mjs --worktree`
+- manual: `node scripts/new-worktree.mjs --feature 999-test-path` lands under `<repoRoot>/.claude/worktrees/999-test-path/`


### PR DESCRIPTION
## Summary

- Swap Claude and Codex roles: Claude now owns architecture, orchestration, CI/CD health, repository memory, and is the default implementation agent driven from the user's local Claude Code terminal session. Codex moves to optional implementation and default review backend. Gemini stays as fallback review; Claude review becomes third-tier.
- Fix worktree location bug: `scripts/new-worktree.mjs` creates worktrees at `<repoRoot>/.claude/worktrees/<slug>/` instead of `~/projects/dreamboard-<slug>/`, with default branch prefix `claude/<slug>`. Local agent state moves from `.codex/` to `.claude/` with a legacy fallback in the worker script.
- Tracked in `specs/004-claude-primary-orchestrator/` with spec, plan, and tasks. Docs updated across constitution, six devops docs, AGENTS.md, README.md, and workflow defaults (`ai-review.yml`, `ai-command-policy.yml`).

## Test plan

- [x] `pnpm run ci` green locally (check:repo, check:html, build, format:check)
- [x] `node scripts/check-feature-memory.mjs --worktree` passes
- [x] Smoke test: `node scripts/new-worktree.mjs --feature 999-smoke-test` lands under `.claude/worktrees/999-smoke-test/` on branch `claude/999-smoke-test`, then cleaned up
- [ ] `baseline-checks`, `guard`, `AI Review`, and Vercel preview green on the PR head SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)