### PR TITLE
chore: document review backend trigger constraints and ship fallback helper

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -73,22 +73,24 @@ jobs:
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             trigger_mode="${{ inputs.trigger_mode || 'skip' }}"
-          elif [ "$selected" = "codex" ]; then
-            # Codex Cloud rejects review triggers posted by GitHub bots
-            # (connector replies with "trigger did not come from a
-            # connected human Codex account"), so bot-posted `@codex
-            # review` cannot auto-retrigger on synchronize. Passive
-            # same-head detection stays in place and the
-            # pnpm run review:switch helper handles manual recovery.
-            trigger_mode="skip"
-          elif [ "$selected" = "claude" ]; then
-            # Claude review is human-initiated only: claude-review.yml
-            # gates on trusted-author issue_comment events, so a
-            # bot-posted `@claude review once` would not dispatch the
-            # actual reviewer.
-            trigger_mode="skip"
           else
-            trigger_mode="comment"
+            # None of the supported review backends accept bot-posted
+            # trigger comments on pull_request events:
+            # - Codex Cloud replies "trigger did not come from a
+            #   connected human Codex account" and fails fast.
+            # - Gemini Code Assist silently ignores bot-posted
+            #   /gemini review and never emits a review; the gate
+            #   times out waiting for it.
+            # - claude-review.yml gates on OWNER/MEMBER/COLLABORATOR
+            #   author_association, so bot-posted @claude review once
+            #   never dispatches the actual reviewer.
+            # Gate therefore stays in skip mode on every pull_request
+            # event. Codex Cloud's on-open auto-review covers initial
+            # PR review; manual recovery on synchronize uses
+            # pnpm run review:switch or a trusted human trigger.
+            # See docs_dreamboard/project/devops/ai-runner.md §Backend
+            # Trigger Constraints for the full matrix.
+            trigger_mode="skip"
           fi
 
           echo "selected_agent=$selected" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -96,6 +96,16 @@ jobs:
           echo "selected_agent=$selected" >> "$GITHUB_OUTPUT"
           echo "trigger_mode=$trigger_mode" >> "$GITHUB_OUTPUT"
 
+          {
+            echo "## AI Review policy"
+            echo ""
+            echo "- selected agent: \`$selected\`"
+            echo "- trigger mode: \`$trigger_mode\`"
+            echo "- event: \`${{ github.event_name }}\`"
+            echo ""
+            echo "See docs_dreamboard/project/devops/ai-runner.md §Backend Trigger Constraints for why no backend auto-retriggers on pull_request events."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Mark native review start
         id: start
         run: echo "triggered_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -73,7 +73,10 @@ jobs:
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             trigger_mode="${{ inputs.trigger_mode || 'skip' }}"
-          elif [ "$selected" = "codex" ]; then
+          elif [ "$selected" = "claude" ]; then
+            # Claude review is human-initiated only: claude-review.yml gates
+            # on trusted-author issue_comment events, so a bot-posted
+            # `@claude review once` would not dispatch the actual reviewer.
             trigger_mode="skip"
           else
             trigger_mode="comment"

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -73,10 +73,19 @@ jobs:
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             trigger_mode="${{ inputs.trigger_mode || 'skip' }}"
+          elif [ "$selected" = "codex" ]; then
+            # Codex Cloud rejects review triggers posted by GitHub bots
+            # (connector replies with "trigger did not come from a
+            # connected human Codex account"), so bot-posted `@codex
+            # review` cannot auto-retrigger on synchronize. Passive
+            # same-head detection stays in place and the
+            # pnpm run review:switch helper handles manual recovery.
+            trigger_mode="skip"
           elif [ "$selected" = "claude" ]; then
-            # Claude review is human-initiated only: claude-review.yml gates
-            # on trusted-author issue_comment events, so a bot-posted
-            # `@claude review once` would not dispatch the actual reviewer.
+            # Claude review is human-initiated only: claude-review.yml
+            # gates on trusted-author issue_comment events, so a
+            # bot-posted `@claude review once` would not dispatch the
+            # actual reviewer.
             trigger_mode="skip"
           else
             trigger_mode="comment"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .vercel/
 .codex/
 .claude/
+.omc/

--- a/docs_dreamboard/project/devops/ai-pr-workflow.md
+++ b/docs_dreamboard/project/devops/ai-pr-workflow.md
@@ -45,11 +45,16 @@ This is the canonical PR loop for `dreamboard`.
 - Supported review backends are `codex`, `gemini`, and `claude`.
 - `AI Review` is the normalized required check regardless of the backend.
 - Low-severity-only findings are advisory and non-blocking.
-- With no repository override, the pull-request gate defaults to `codex` and
-  uses passive same-head detection instead of posting a bot-authored trigger
-  comment.
-- When `AI_REVIEW_AGENT=gemini`, the pull-request gate posts a single
-  bot-authored `/gemini review` trigger comment for the current PR head.
+- With no repository override, the pull-request gate defaults to `codex`.
+- On every `pull_request` event (including `synchronize` after a new push),
+  the gate posts the native trigger comment for the selected reviewer
+  (`@codex review` for Codex, `/gemini review` for Gemini) so the reviewer
+  re-reviews the current head SHA without human interaction.
+- Claude review is human-initiated only: a trusted `@claude review once`
+  comment dispatches the Claude review workflow through
+  `ai-command-policy.yml`; the gate never auto-posts it.
+- Trigger comments are deduplicated per head SHA via a hidden metadata
+  marker so workflow reruns and repeated events do not spam the PR.
 - Manual Gemini and Codex review commands stay native-only so they do not
   cancel the PR-linked `AI Review` check.
 - Rerunning the PR-linked `AI Review` workflow is enough to reuse same-head

--- a/docs_dreamboard/project/devops/ai-pr-workflow.md
+++ b/docs_dreamboard/project/devops/ai-pr-workflow.md
@@ -46,15 +46,22 @@ This is the canonical PR loop for `dreamboard`.
 - `AI Review` is the normalized required check regardless of the backend.
 - Low-severity-only findings are advisory and non-blocking.
 - With no repository override, the pull-request gate defaults to `codex`.
-- On every `pull_request` event (including `synchronize` after a new push),
-  the gate posts the native trigger comment for the selected reviewer
-  (`@codex review` for Codex, `/gemini review` for Gemini) so the reviewer
-  re-reviews the current head SHA without human interaction.
+- On `pull_request` events with `AI_REVIEW_AGENT=gemini`, the gate posts
+  `/gemini review` for the current head SHA so Gemini re-reviews new
+  commits automatically.
+- Codex auto-retrigger on `synchronize` is not supported: Codex Cloud
+  rejects bot-posted `@codex review` triggers (connector replies with
+  "trigger did not come from a connected human Codex account"). The gate
+  therefore keeps `trigger_mode=skip` for Codex and passively waits for a
+  same-head native review. After a new push, post `@codex review`
+  manually from a Codex-connected account, or run
+  `pnpm run review:switch -- --to gemini` to switch backends for this PR.
 - Claude review is human-initiated only: a trusted `@claude review once`
   comment dispatches the Claude review workflow through
   `ai-command-policy.yml`; the gate never auto-posts it.
-- Trigger comments are deduplicated per head SHA via a hidden metadata
-  marker so workflow reruns and repeated events do not spam the PR.
+- Trigger comments for Gemini are deduplicated per head SHA via a hidden
+  metadata marker so workflow reruns and repeated events do not spam the
+  PR.
 - Manual Gemini and Codex review commands stay native-only so they do not
   cancel the PR-linked `AI Review` check.
 - Rerunning the PR-linked `AI Review` workflow is enough to reuse same-head

--- a/docs_dreamboard/project/devops/ai-pr-workflow.md
+++ b/docs_dreamboard/project/devops/ai-pr-workflow.md
@@ -46,22 +46,19 @@ This is the canonical PR loop for `dreamboard`.
 - `AI Review` is the normalized required check regardless of the backend.
 - Low-severity-only findings are advisory and non-blocking.
 - With no repository override, the pull-request gate defaults to `codex`.
-- On `pull_request` events with `AI_REVIEW_AGENT=gemini`, the gate posts
-  `/gemini review` for the current head SHA so Gemini re-reviews new
-  commits automatically.
-- Codex auto-retrigger on `synchronize` is not supported: Codex Cloud
-  rejects bot-posted `@codex review` triggers (connector replies with
-  "trigger did not come from a connected human Codex account"). The gate
-  therefore keeps `trigger_mode=skip` for Codex and passively waits for a
-  same-head native review. After a new push, post `@codex review`
-  manually from a Codex-connected account, or run
-  `pnpm run review:switch -- --to gemini` to switch backends for this PR.
-- Claude review is human-initiated only: a trusted `@claude review once`
-  comment dispatches the Claude review workflow through
-  `ai-command-policy.yml`; the gate never auto-posts it.
-- Trigger comments for Gemini are deduplicated per head SHA via a hidden
-  metadata marker so workflow reruns and repeated events do not spam the
-  PR.
+- Auto-retrigger on `synchronize` is not supported for any backend: all
+  three reject bot-posted trigger comments (see
+  `docs_dreamboard/project/devops/ai-runner.md` §Backend Trigger
+  Constraints and `docs_dreamboard/project/devops/review-contract.md`
+  §Backend Trigger Constraints). The gate therefore stays in
+  `trigger_mode=skip` on every `pull_request` event and passively waits
+  for a same-head native review.
+- Initial PR review is covered by Codex Cloud's and Gemini Code Assist's
+  on-open auto-review. After a new push on an already-open PR, a human
+  must post the appropriate native trigger comment
+  (`@codex review`, `/gemini review`, or `@claude review once`), or run
+  `pnpm run review:switch -- --to <agent>` to flip backends and trigger
+  the new reviewer in one shot.
 - Manual Gemini and Codex review commands stay native-only so they do not
   cancel the PR-linked `AI Review` check.
 - Rerunning the PR-linked `AI Review` workflow is enough to reuse same-head

--- a/docs_dreamboard/project/devops/ai-runner.md
+++ b/docs_dreamboard/project/devops/ai-runner.md
@@ -39,15 +39,20 @@ with an explanatory comment instead of silently skipping.
 `AI Review` is a normalization layer on top of native vendor review outputs.
 
 - Codex path waits for native GitHub PR review output from
-  `chatgpt-codex-connector[bot]` (default). On every `pull_request` event
-  (including `synchronize` after a new push), the gate posts `@codex review`
-  for the current head SHA so Codex Cloud re-reviews the latest commit
-  without human interaction.
+  `chatgpt-codex-connector[bot]` (default). Codex Cloud rejects review
+  triggers posted by GitHub bots — the connector replies with "trigger
+  did not come from a connected human Codex account" — so the gate
+  cannot auto-retrigger Codex on `synchronize`. On fresh PR open and
+  ready-for-review, Codex Cloud auto-reviews on its own; after a new
+  push on an already-reviewed PR, a human must post `@codex review`
+  from a Codex-connected account, or switch backend via
+  `pnpm run review:switch -- --to gemini`.
 - Gemini path waits for native GitHub PR review output from
   `gemini-code-assist[bot]` and classifies inline review comments by
-  `Critical`, `High`, `Medium`, and `Low` severity markers. The gate also
+  `Critical`, `High`, `Medium`, and `Low` severity markers. The gate
   posts `/gemini review` on every `pull_request` event for the current
-  head SHA.
+  head SHA when `AI_REVIEW_AGENT=gemini`, so Gemini re-reviews new
+  commits automatically.
 - Claude path waits for a top-level `claude[bot]` comment containing:
   - `AI_REVIEW_AGENT: claude`
   - `AI_REVIEW_SHA: <head sha>`

--- a/docs_dreamboard/project/devops/ai-runner.md
+++ b/docs_dreamboard/project/devops/ai-runner.md
@@ -34,40 +34,65 @@ Local macOS helper scripts may also store the current selection under:
 If a selected backend is missing its requirements, the workflow fails closed
 with an explanatory comment instead of silently skipping.
 
+## Backend Trigger Constraints
+
+None of the supported review backends accept bot-posted trigger comments
+on `pull_request` events. This matrix is the single source of truth for
+why `ai-review.yml` keeps `trigger_mode=skip` on every `pull_request`
+event regardless of the selected backend, and it is the setup guidance
+to copy to any future repository that adopts this AI review pattern.
+
+| Backend                                | Auto-review on `opened` / `ready_for_review` | Auto-review on `synchronize` | Accepts bot-posted trigger comment                                                                                          | Manual recovery path                                                                 |
+| -------------------------------------- | -------------------------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Codex (`chatgpt-codex-connector[bot]`) | yes (Codex Cloud auto-reviews on PR open)    | no                           | **no** — connector replies "trigger did not come from a connected human Codex account" and the gate fails fast              | trusted human posts `@codex review`, or run `pnpm run review:switch -- --to <other>` |
+| Gemini (`gemini-code-assist[bot]`)     | yes when the GitHub App is installed         | no                           | **no** — silently ignored, the gate times out after 20 minutes                                                              | trusted human posts `/gemini review` (responses arrive within ~2 minutes)            |
+| Claude (`claude[bot]`)                 | no                                           | no                           | **no** — `claude-review.yml` gates on `author_association in (OWNER, MEMBER, COLLABORATOR)` and drops bot-authored comments | trusted human posts `@claude review once`                                            |
+
+Consequences for orchestration design:
+
+- Auto-retrigger on `synchronize` is not achievable from within a stock
+  GitHub Actions workflow. A user PAT from a Codex-connected account or
+  a dedicated service account with trusted `author_association` would
+  be required to bypass this, and neither is in scope for `dreamboard`.
+- Codex Cloud's on-open auto-review covers the initial PR review for
+  free. Every subsequent push needs a manual trigger or a backend
+  switch.
+- The `pnpm run review:switch` helper is the canonical one-shot
+  recovery path: it flips `AI_REVIEW_AGENT`, posts the correct native
+  trigger comment on behalf of the current user (via `gh` CLI, so the
+  comment is human-authored and trusted), and reruns the most recent
+  failed `AI Review` job on the current head SHA.
+
 ## Review Gate
 
 `AI Review` is a normalization layer on top of native vendor review outputs.
 
 - Codex path waits for native GitHub PR review output from
-  `chatgpt-codex-connector[bot]` (default). Codex Cloud rejects review
-  triggers posted by GitHub bots — the connector replies with "trigger
-  did not come from a connected human Codex account" — so the gate
-  cannot auto-retrigger Codex on `synchronize`. On fresh PR open and
-  ready-for-review, Codex Cloud auto-reviews on its own; after a new
-  push on an already-reviewed PR, a human must post `@codex review`
-  from a Codex-connected account, or switch backend via
-  `pnpm run review:switch -- --to gemini`.
+  `chatgpt-codex-connector[bot]` (default). Codex Cloud auto-reviews on
+  PR open and ready-for-review; on `synchronize` after a new push a
+  human must post `@codex review` or switch backends via
+  `pnpm run review:switch`.
 - Gemini path waits for native GitHub PR review output from
   `gemini-code-assist[bot]` and classifies inline review comments by
-  `Critical`, `High`, `Medium`, and `Low` severity markers. The gate
-  posts `/gemini review` on every `pull_request` event for the current
-  head SHA when `AI_REVIEW_AGENT=gemini`, so Gemini re-reviews new
-  commits automatically.
+  `Critical`, `High`, `Medium`, and `Low` severity markers. Gemini
+  responds only to human-authored `/gemini review` comments on an
+  already-open PR; it ignores bot-posted triggers on `synchronize`.
 - Claude path waits for a top-level `claude[bot]` comment containing:
   - `AI_REVIEW_AGENT: claude`
   - `AI_REVIEW_SHA: <head sha>`
   - `AI_REVIEW_OUTCOME: pass|advisory|block`
     Claude review is human-initiated only: a trusted
     `@claude review once` comment dispatches `claude-review.yml`. Bot-posted
-    triggers are ignored by that workflow, so the gate does not auto-post
+    triggers are ignored by that workflow, so the gate never auto-posts
     `@claude review once`.
 
-Each trigger comment carries a hidden metadata marker
-`<!-- ai-review-gate:agent=<agent>;sha=<head> -->`. When the gate would
-post a new trigger comment, it first scans PR comments from the last 30
-minutes for a matching marker and reuses the existing comment instead of
-posting a duplicate. This prevents trigger-comment spam on workflow
-reruns and on repeated `pull_request` events for the same head SHA.
+When the gate does post a trigger comment (only possible via
+`workflow_dispatch` with `inputs.trigger_mode=comment`), each comment
+carries a hidden metadata marker
+`<!-- ai-review-gate:agent=<agent>;sha=<head> -->`. The gate scans PR
+comments from the last 30 minutes for a matching marker and reuses the
+existing comment instead of posting a duplicate. This prevents trigger
+spam on repeated manual dispatches against the same head SHA.
 
 The gate passes on:
 

--- a/docs_dreamboard/project/devops/ai-runner.md
+++ b/docs_dreamboard/project/devops/ai-runner.md
@@ -39,14 +39,30 @@ with an explanatory comment instead of silently skipping.
 `AI Review` is a normalization layer on top of native vendor review outputs.
 
 - Codex path waits for native GitHub PR review output from
-  `chatgpt-codex-connector[bot]` (default).
+  `chatgpt-codex-connector[bot]` (default). On every `pull_request` event
+  (including `synchronize` after a new push), the gate posts `@codex review`
+  for the current head SHA so Codex Cloud re-reviews the latest commit
+  without human interaction.
 - Gemini path waits for native GitHub PR review output from
   `gemini-code-assist[bot]` and classifies inline review comments by
-  `Critical`, `High`, `Medium`, and `Low` severity markers.
+  `Critical`, `High`, `Medium`, and `Low` severity markers. The gate also
+  posts `/gemini review` on every `pull_request` event for the current
+  head SHA.
 - Claude path waits for a top-level `claude[bot]` comment containing:
   - `AI_REVIEW_AGENT: claude`
   - `AI_REVIEW_SHA: <head sha>`
   - `AI_REVIEW_OUTCOME: pass|advisory|block`
+    Claude review is human-initiated only: a trusted
+    `@claude review once` comment dispatches `claude-review.yml`. Bot-posted
+    triggers are ignored by that workflow, so the gate does not auto-post
+    `@claude review once`.
+
+Each trigger comment carries a hidden metadata marker
+`<!-- ai-review-gate:agent=<agent>;sha=<head> -->`. When the gate would
+post a new trigger comment, it first scans PR comments from the last 30
+minutes for a matching marker and reuses the existing comment instead of
+posting a duplicate. This prevents trigger-comment spam on workflow
+reruns and on repeated `pull_request` events for the same head SHA.
 
 The gate passes on:
 

--- a/docs_dreamboard/project/devops/macos-local-runners.md
+++ b/docs_dreamboard/project/devops/macos-local-runners.md
@@ -77,6 +77,33 @@ node scripts/publish-branch.mjs \
   --title "chore: swap claude and codex roles and move worktrees inside repo"
 ```
 
+## Fallback Review Agent
+
+When the selected review backend stalls, hits rate limits, or returns
+unexpected output on an open PR, you can flip the policy and re-trigger
+the `AI Review` gate with a single command from the current worktree:
+
+```bash
+pnpm run review:switch -- --to gemini
+```
+
+The helper resolves the open PR for the current branch, flips the
+`AI_REVIEW_AGENT` repository variable via `gh variable set`, posts the
+correct native trigger comment on the PR (`@codex review`,
+`/gemini review`, or `@claude review once`), and reruns the most recent
+failed `AI Review` run on the current head SHA.
+
+Optional flags:
+
+- `--pr <number>` — target a specific PR instead of the current branch
+- `--no-rerun` — flip and comment without rerunning
+- `--no-comment` — flip and rerun without posting a trigger comment
+- `--repo <owner/name>` — target a different repository
+
+Use this for one-shot recovery when Codex is rate-limited (fall back to
+Gemini), when Gemini is silent (fall back to Claude), or when you want to
+quickly compare output from a different backend on the same head SHA.
+
 ## Trade-Offs
 
 - The repository prepares prompts and branch/worktree state, but it does not

--- a/docs_dreamboard/project/devops/review-contract.md
+++ b/docs_dreamboard/project/devops/review-contract.md
@@ -1,5 +1,30 @@
 # Review Contract
 
+## Backend Trigger Constraints
+
+All three supported review backends require a **human-authored** trigger
+on `pull_request: synchronize` events. Bot-posted trigger comments from
+GitHub Actions (`github-actions[bot]`) are rejected silently or with an
+explicit error by every backend:
+
+- **Codex** — the connector replies "trigger did not come from a
+  connected human Codex account" and the `AI Review` gate fails fast.
+- **Gemini** — `gemini-code-assist[bot]` silently ignores bot-posted
+  `/gemini review` comments; the gate times out after 20 minutes.
+- **Claude** — `claude-review.yml` gates on `author_association in
+(OWNER, MEMBER, COLLABORATOR)` and drops anything authored by a bot.
+
+Codex Cloud's on-open auto-review (on `opened` and `ready_for_review`)
+and Gemini Code Assist's on-open auto-review cover the initial review
+for free, but every new push on an already-open PR needs a manual
+trigger. The canonical recovery path is
+`pnpm run review:switch -- --to <agent>`, which flips the repository
+variable, posts the correct native trigger comment as the current `gh`
+user (human-authored, therefore trusted), and reruns the most recent
+failed `AI Review` job.
+
+See `docs_dreamboard/project/devops/ai-runner.md` for the full matrix.
+
 ## Codex Review
 
 - Default review backend for `dreamboard`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format:check": "prettier --check \"index.html\" \"src/**/*.{css,js}\" \"AGENTS.md\" \"CLAUDE.md\" \".specify/**/*.md\" \"specs/**/*.md\" \"docs_dreamboard/**/*.md\" \".github/workflows/*.{yml,yaml}\" \".gemini/**/*.{md,yaml,yml}\" \"scripts/**/*.mjs\" \"package.json\" \"vercel.json\" \".htmlvalidate.json\"",
     "ci": "pnpm run check:repo && pnpm run check:html && pnpm run build && pnpm run format:check",
     "pr:publish": "node scripts/publish-branch.mjs",
+    "review:switch": "node scripts/switch-review-agent.mjs",
     "worker:start": "node scripts/start-implementation-worker.mjs",
     "worktree:new": "node scripts/new-worktree.mjs"
   },

--- a/scripts/ai-review-gate.mjs
+++ b/scripts/ai-review-gate.mjs
@@ -205,6 +205,26 @@ const buildTriggerComment = () => {
 };
 
 const ensureTriggerComment = async () => {
+  // Dedupe: reuse an existing gate-originated trigger comment for the
+  // current head SHA within the last 30 minutes instead of posting a
+  // duplicate. The metadata marker encodes both agent and headSha, so a
+  // match is unambiguous. Prevents trigger-comment spam on workflow
+  // reruns and on repeated pull_request events for the same head.
+  const dedupeWindowMs = 30 * 60 * 1000;
+  const recentComments = await listPaginated(
+    buildIssueCommentsPath(Date.now() - dedupeWindowMs),
+  );
+  const existing = recentComments.find((comment) =>
+    (comment.body || "").includes(metadataMarker),
+  );
+
+  if (existing) {
+    console.log(
+      `Reusing existing gate trigger comment for ${selectedAgent} at ${headSha}: ${existing.html_url}`,
+    );
+    return existing;
+  }
+
   return request(`/repos/${owner}/${repo}/issues/${prNumber}/comments`, {
     method: "POST",
     body: JSON.stringify({ body: buildTriggerComment() }),

--- a/scripts/ai-review-gate.mjs
+++ b/scripts/ai-review-gate.mjs
@@ -187,40 +187,67 @@ const buildTriggerComment = () => {
     ].join("\n");
   }
 
-  return [
-    "@claude review once",
-    "",
-    `Please review PR #${prNumber} at head commit \`${headSha}\`.`,
-    "",
-    "In your final top-level Claude comment, begin with exactly these three lines:",
-    markerAgentLine,
-    markerShaLine,
-    `${claudeOutcomePrefix} pass|advisory|block`,
-    "",
-    "This repository validates Claude review via marker comments instead of formal GitHub PR review states.",
-    "Use inline PR comments only for concrete findings, and do not modify code in this workflow.",
-    "",
-    metadataMarker,
-  ].join("\n");
+  // Claude review is human-initiated only: claude-review.yml gates on
+  // author_association in (OWNER, MEMBER, COLLABORATOR), so any
+  // bot-authored @claude review once comment would be dropped and never
+  // dispatch the actual reviewer. ai-review.yml keeps Claude on
+  // trigger_mode=skip on every pull_request event and
+  // workflow_dispatch with inputs.trigger_mode=comment is not a
+  // supported entry point for Claude. Fail loudly here so a future
+  // misconfiguration surfaces as an explicit error instead of a
+  // silently ignored bot comment.
+  throw new Error(
+    `buildTriggerComment() refused: selectedAgent="${selectedAgent}" does not support bot-posted triggers. Claude review requires a human-authored @claude review once comment from a trusted account.`,
+  );
 };
 
+const triggerKeywords = {
+  codex: "@codex review",
+  gemini: "/gemini review",
+  claude: "@claude review once",
+};
+
+const isReviewerBotLogin = (login) =>
+  codexReviewerLogins.has(login) ||
+  geminiReviewerLogins.has(login) ||
+  claudeReviewerLogins.has(login);
+
 const ensureTriggerComment = async () => {
-  // Dedupe: reuse an existing gate-originated trigger comment for the
-  // current head SHA within the last 30 minutes instead of posting a
-  // duplicate. The metadata marker encodes both agent and headSha, so a
-  // match is unambiguous. Prevents trigger-comment spam on workflow
-  // reruns and on repeated pull_request events for the same head.
+  // Dedupe: skip posting a duplicate trigger when either
+  // (a) a gate-originated trigger comment for the current head SHA
+  //     already exists in the last 30 minutes (matched via the hidden
+  //     metadataMarker, which encodes both agent and headSha), or
+  // (b) a non-reviewer author posted the bare backend trigger keyword
+  //     (e.g. `@codex review`, `/gemini review`, `@claude review once`)
+  //     in the same window. Case (b) covers trusted humans who already
+  //     triggered native review via ai-command-policy.yml so the gate
+  //     does not fan out a duplicate native review or add rate-limit
+  //     pressure. Comments authored by any of the review backend bots
+  //     themselves are excluded so connector replies and summary
+  //     comments are never treated as triggers.
   const dedupeWindowMs = 30 * 60 * 1000;
+  const triggerKeyword = triggerKeywords[selectedAgent];
   const recentComments = await listPaginated(
     buildIssueCommentsPath(Date.now() - dedupeWindowMs),
   );
-  const existing = recentComments.find((comment) =>
-    (comment.body || "").includes(metadataMarker),
-  );
+  const existing = recentComments.find((comment) => {
+    const body = comment.body || "";
+    if (body.includes(metadataMarker)) {
+      return true;
+    }
+    if (
+      triggerKeyword &&
+      body.includes(triggerKeyword) &&
+      !isReviewerBotLogin(comment.user?.login || "")
+    ) {
+      return true;
+    }
+    return false;
+  });
 
   if (existing) {
     console.log(
-      `Reusing existing gate trigger comment for ${selectedAgent} at ${headSha}: ${existing.html_url}`,
+      `Reusing existing trigger comment for ${selectedAgent} at ${headSha}: ${existing.html_url}`,
     );
     return existing;
   }

--- a/scripts/switch-review-agent.mjs
+++ b/scripts/switch-review-agent.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+const options = {
+  to: "",
+  pr: "",
+  rerun: true,
+  comment: true,
+  repo: "",
+};
+
+const usage = [
+  "Usage:",
+  "  node scripts/switch-review-agent.mjs --to <codex|gemini|claude> [--pr <number>] [--no-rerun] [--no-comment] [--repo <owner/name>]",
+].join("\n");
+
+for (let index = 0; index < args.length; index += 1) {
+  const current = args[index];
+
+  switch (current) {
+    case "--to":
+      options.to = (args[index + 1] || "").trim().toLowerCase();
+      index += 1;
+      break;
+    case "--pr":
+      options.pr = (args[index + 1] || "").trim();
+      index += 1;
+      break;
+    case "--no-rerun":
+      options.rerun = false;
+      break;
+    case "--no-comment":
+      options.comment = false;
+      break;
+    case "--repo":
+      options.repo = (args[index + 1] || "").trim();
+      index += 1;
+      break;
+    default:
+      throw new Error(`Unknown argument: ${current}\n\n${usage}`);
+  }
+}
+
+const validAgents = new Set(["codex", "gemini", "claude"]);
+if (!validAgents.has(options.to)) {
+  throw new Error(`--to must be one of: codex, gemini, claude\n\n${usage}`);
+}
+
+const triggerBodies = {
+  codex: "@codex review",
+  gemini: "/gemini review",
+  claude: "@claude review once",
+};
+
+const run = (command, commandArgs) =>
+  execFileSync(command, commandArgs, {
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  }).trim();
+
+const repoArgs = options.repo ? ["--repo", options.repo] : [];
+
+// Step 0: resolve PR number from the current branch if not supplied.
+if (!options.pr) {
+  const json = run("gh", ["pr", "view", "--json", "number", ...repoArgs]);
+  if (!json) {
+    throw new Error(
+      "No open PR detected for the current branch. Pass --pr <number> explicitly.",
+    );
+  }
+  options.pr = String(JSON.parse(json).number);
+}
+
+// Step 1: flip the AI_REVIEW_AGENT repository variable.
+run("gh", [
+  "variable",
+  "set",
+  "AI_REVIEW_AGENT",
+  "--body",
+  options.to,
+  ...repoArgs,
+]);
+console.log(`Repository variable AI_REVIEW_AGENT set to ${options.to}.`);
+
+// Step 2: post the native trigger comment on the target PR.
+if (options.comment) {
+  run("gh", [
+    "pr",
+    "comment",
+    options.pr,
+    "--body",
+    triggerBodies[options.to],
+    ...repoArgs,
+  ]);
+  console.log(`Posted "${triggerBodies[options.to]}" on PR #${options.pr}.`);
+} else {
+  console.log("Skipped native trigger comment because --no-comment was used.");
+}
+
+// Step 3: rerun the most recent failed AI Review run at the current head SHA.
+if (options.rerun) {
+  const prJson = run("gh", [
+    "pr",
+    "view",
+    options.pr,
+    "--json",
+    "headRefOid",
+    ...repoArgs,
+  ]);
+  const headSha = JSON.parse(prJson).headRefOid;
+
+  const runsJson = run("gh", [
+    "run",
+    "list",
+    "--workflow",
+    "ai-review.yml",
+    "--limit",
+    "10",
+    "--json",
+    "databaseId,conclusion,headSha",
+    ...repoArgs,
+  ]);
+  const runs = JSON.parse(runsJson);
+  const target = runs.find(
+    (entry) => entry.headSha === headSha && entry.conclusion === "failure",
+  );
+
+  if (target) {
+    run("gh", [
+      "run",
+      "rerun",
+      String(target.databaseId),
+      "--failed",
+      ...repoArgs,
+    ]);
+    console.log(
+      `Re-run dispatched for failed AI Review run ${target.databaseId}.`,
+    );
+  } else {
+    console.log(
+      "No failed AI Review run found for the current head SHA; skipping rerun.",
+    );
+  }
+} else {
+  console.log("Skipped AI Review rerun because --no-rerun was used.");
+}

--- a/scripts/switch-review-agent.mjs
+++ b/scripts/switch-review-agent.mjs
@@ -64,8 +64,10 @@ const repoArgs = options.repo ? ["--repo", options.repo] : [];
 
 // Step 0: resolve PR number from the current branch if not supplied.
 if (!options.pr) {
-  const json = run("gh", ["pr", "view", "--json", "number", ...repoArgs]);
-  if (!json) {
+  let json;
+  try {
+    json = run("gh", ["pr", "view", "--json", "number", ...repoArgs]);
+  } catch (error) {
     throw new Error(
       "No open PR detected for the current branch. Pass --pr <number> explicitly.",
     );
@@ -123,8 +125,19 @@ if (options.rerun) {
     ...repoArgs,
   ]);
   const runs = JSON.parse(runsJson);
+  // Match any non-success terminal conclusion so the helper also
+  // rescues Gemini-silent-timeout runs and cancelled reruns, not just
+  // explicit failures.
+  const rerunableConclusions = new Set([
+    "failure",
+    "timed_out",
+    "cancelled",
+    "startup_failure",
+    "action_required",
+  ]);
   const target = runs.find(
-    (entry) => entry.headSha === headSha && entry.conclusion === "failure",
+    (entry) =>
+      entry.headSha === headSha && rerunableConclusions.has(entry.conclusion),
   );
 
   if (target) {

--- a/scripts/switch-review-agent.mjs
+++ b/scripts/switch-review-agent.mjs
@@ -141,19 +141,24 @@ if (options.rerun) {
   );
 
   if (target) {
-    run("gh", [
-      "run",
-      "rerun",
-      String(target.databaseId),
-      "--failed",
-      ...repoArgs,
-    ]);
+    // `gh run rerun --failed` only reruns jobs whose conclusion is
+    // literally `failure`. For runs that ended in `cancelled`,
+    // `timed_out`, `startup_failure`, or `action_required` there
+    // may be no `failure`-conclusion jobs at all, so `--failed`
+    // would fail the command. Rerun the whole run in those cases
+    // and keep the targeted `--failed` behavior only for actual
+    // job failures.
+    const rerunArgs = ["run", "rerun", String(target.databaseId), ...repoArgs];
+    if (target.conclusion === "failure") {
+      rerunArgs.push("--failed");
+    }
+    run("gh", rerunArgs);
     console.log(
-      `Re-run dispatched for failed AI Review run ${target.databaseId}.`,
+      `Re-run dispatched for AI Review run ${target.databaseId} (conclusion: ${target.conclusion}).`,
     );
   } else {
     console.log(
-      "No failed AI Review run found for the current head SHA; skipping rerun.",
+      "No rerunable AI Review run found for the current head SHA; skipping rerun.",
     );
   }
 } else {

--- a/specs/005-ai-review-auto-retrigger-and-fallback/plan.md
+++ b/specs/005-ai-review-auto-retrigger-and-fallback/plan.md
@@ -1,0 +1,75 @@
+# Plan
+
+## Slice 1: Housekeeping
+
+- add `.omc/` to `.gitignore` so the oh-my-claudecode local state
+  (`notepad.md`, `project-memory.json`) stops surfacing as untracked on
+  every branch
+
+## Slice 2: Auto-retrigger in the `AI Review` workflow
+
+- rewrite the `Resolve selected review policy` step in
+  `.github/workflows/ai-review.yml`:
+  - keep `trigger_mode=skip` only for `workflow_dispatch` runs that
+    pass `inputs.trigger_mode=skip` (i.e. trusted human commands that
+    have already produced a native review comment themselves)
+  - for `pull_request` events (`opened`, `synchronize`, `reopened`,
+    `ready_for_review`), set `trigger_mode=comment` for all three
+    backends including Codex, so the gate posts the appropriate native
+    trigger comment for the current head SHA
+- teach `scripts/ai-review-gate.mjs` to pick the trigger comment text
+  by selected backend:
+  - `codex` → `@codex review`
+  - `gemini` → `/gemini review`
+  - `claude` → `@claude review once` (already handled)
+- add a same-head dedupe guard: before posting the trigger comment,
+  check existing PR comments for a matching trigger body that targets
+  the current head SHA within the last 30 minutes; skip posting if
+  one already exists
+- keep existing Gemini-specific note in place — Gemini already uses
+  `trigger_mode=comment`, the new change only generalizes Codex to the
+  same path
+
+## Slice 3: Fallback helper `scripts/switch-review-agent.mjs`
+
+- new helper script:
+  - parses `--to <codex|gemini|claude>` required arg
+  - optional `--pr <number>` (defaults to the PR for the current
+    branch via `gh pr view --json number`)
+  - optional `--rerun` flag (default true) to rerun failed `AI Review`
+    runs on the latest head SHA of the target PR
+  - executes: (a) `gh variable set AI_REVIEW_AGENT --body <agent>`,
+    (b) `gh pr comment <number> --body <trigger>` with the native
+    trigger text for the new backend, (c) `gh run rerun <id> --failed`
+    for the most recent failed AI Review run on that PR head SHA
+  - prints a human-readable summary of each step
+- expose as `review:switch` script in `package.json` so the common
+  call is `pnpm run review:switch -- --to gemini`
+
+## Slice 4: Documentation
+
+- `docs_dreamboard/project/devops/ai-runner.md`: describe the
+  auto-retrigger step in the `Review Gate` section, including the
+  same-head dedupe behavior
+- `docs_dreamboard/project/devops/ai-pr-workflow.md`: update the
+  "Review Contract" section to note that `AI Review` posts the trigger
+  comment itself on every `synchronize` event, so humans no longer
+  need to manually post `@codex review` on new commits
+- `docs_dreamboard/project/devops/macos-local-runners.md`: add a short
+  "Fallback review agent" subsection under `Recommended Flow` with the
+  `pnpm run review:switch -- --to gemini` invocation and when to use it
+  (rate limits, silent backend, unexpected findings)
+
+## Slice 5: Validation
+
+- `pnpm run ci` inside the worktree (check:repo, check:html, build,
+  format:check)
+- `node scripts/check-feature-memory.mjs --worktree`
+- manual smoke:
+  - push a trivial whitespace commit to the open PR and confirm the
+    `AI Review` run posts `@codex review` automatically without human
+    interaction
+  - run `pnpm run review:switch -- --to gemini` and confirm the
+    variable flips, a `/gemini review` comment appears on the PR, and
+    the most recent failed `AI Review` run reruns
+- green required checks on the final PR head SHA

--- a/specs/005-ai-review-auto-retrigger-and-fallback/plan.md
+++ b/specs/005-ai-review-auto-retrigger-and-fallback/plan.md
@@ -6,24 +6,24 @@
   (`notepad.md`, `project-memory.json`) stops surfacing as untracked on
   every branch
 
-## Slice 2: Auto-retrigger for Gemini only
+## Slice 2: Document constraints and collapse workflow policy to skip
 
-- update the `Resolve selected review policy` step in
-  `.github/workflows/ai-review.yml`:
-  - `workflow_dispatch` runs respect `inputs.trigger_mode` (defaults
-    to `skip`)
-  - Codex stays on `trigger_mode=skip` with an inline comment noting
-    that Codex Cloud rejects bot-posted triggers
-  - Claude stays on `trigger_mode=skip` because `claude-review.yml`
-    gates on trusted-author issue_comment events
-  - Gemini (the only backend that accepts bot-posted triggers on
-    `synchronize`) falls through to `trigger_mode=comment`
+- rewrite the `Resolve selected review policy` step in
+  `.github/workflows/ai-review.yml` so every `pull_request` event
+  resolves `trigger_mode=skip`, regardless of the selected backend.
+  Keep `workflow_dispatch` runs honoring `inputs.trigger_mode`
+  (default `skip`) so manual dispatches can still opt into comment
+  mode for future backends that support bot triggers.
+- inline comments in the workflow enumerate the per-backend reason
+  (Codex rejects, Gemini ignores, Claude gates on human author) and
+  link to
+  `docs_dreamboard/project/devops/ai-runner.md` §Backend Trigger
+  Constraints.
 - `scripts/ai-review-gate.mjs` already picks the trigger comment text
   by selected backend via `buildTriggerComment()`; no changes there
-- add a same-head dedupe guard in `ensureTriggerComment()`: before
-  posting a Gemini trigger comment, look for an existing gate comment
-  with the current head SHA's `metadataMarker` within the last 30
-  minutes; reuse the existing comment instead of posting a duplicate
+  beyond the 30-minute same-head dedupe guard in
+  `ensureTriggerComment()`, which protects against duplicate trigger
+  comments on repeated manual dispatches for the same head SHA.
 
 ## Slice 3: Fallback helper `scripts/switch-review-agent.mjs`
 
@@ -43,13 +43,18 @@
 
 ## Slice 4: Documentation
 
-- `docs_dreamboard/project/devops/ai-runner.md`: describe the
-  auto-retrigger step in the `Review Gate` section, including the
-  same-head dedupe behavior
+- `docs_dreamboard/project/devops/ai-runner.md`: add the
+  `§Backend Trigger Constraints` section with the full matrix
+  (auto-review on open, auto-review on synchronize, accepts bot
+  trigger, manual recovery) and update the Review Gate subsection to
+  match
+- `docs_dreamboard/project/devops/review-contract.md`: add a
+  `§Backend Trigger Constraints` header that summarizes the same
+  finding and cross-links to `ai-runner.md`
 - `docs_dreamboard/project/devops/ai-pr-workflow.md`: update the
-  "Review Contract" section to note that `AI Review` posts the trigger
-  comment itself on every `synchronize` event, so humans no longer
-  need to manually post `@codex review` on new commits
+  "Review Contract" section to explicitly say that no backend
+  auto-retriggers on `synchronize` and that recovery uses
+  `pnpm run review:switch` or a trusted human trigger comment
 - `docs_dreamboard/project/devops/macos-local-runners.md`: add a short
   "Fallback review agent" subsection under `Recommended Flow` with the
   `pnpm run review:switch -- --to gemini` invocation and when to use it

--- a/specs/005-ai-review-auto-retrigger-and-fallback/plan.md
+++ b/specs/005-ai-review-auto-retrigger-and-fallback/plan.md
@@ -66,10 +66,11 @@
   format:check)
 - `node scripts/check-feature-memory.mjs --worktree`
 - manual smoke:
-  - push a trivial whitespace commit to the open PR and confirm the
-    `AI Review` run posts `@codex review` automatically without human
-    interaction
+  - push a trivial commit to an open PR and confirm the gate stays in
+    `trigger_mode=skip` (no bot-authored trigger comment is posted and
+    the gate passively polls for a same-head native review)
   - run `pnpm run review:switch -- --to gemini` and confirm the
-    variable flips, a `/gemini review` comment appears on the PR, and
-    the most recent failed `AI Review` run reruns
+    variable flips, a human-authored `/gemini review` comment appears
+    on the PR, and the most recent failed / timed-out / cancelled
+    `AI Review` run reruns
 - green required checks on the final PR head SHA

--- a/specs/005-ai-review-auto-retrigger-and-fallback/plan.md
+++ b/specs/005-ai-review-auto-retrigger-and-fallback/plan.md
@@ -6,29 +6,24 @@
   (`notepad.md`, `project-memory.json`) stops surfacing as untracked on
   every branch
 
-## Slice 2: Auto-retrigger in the `AI Review` workflow
+## Slice 2: Auto-retrigger for Gemini only
 
-- rewrite the `Resolve selected review policy` step in
+- update the `Resolve selected review policy` step in
   `.github/workflows/ai-review.yml`:
-  - keep `trigger_mode=skip` only for `workflow_dispatch` runs that
-    pass `inputs.trigger_mode=skip` (i.e. trusted human commands that
-    have already produced a native review comment themselves)
-  - for `pull_request` events (`opened`, `synchronize`, `reopened`,
-    `ready_for_review`), set `trigger_mode=comment` for all three
-    backends including Codex, so the gate posts the appropriate native
-    trigger comment for the current head SHA
-- teach `scripts/ai-review-gate.mjs` to pick the trigger comment text
-  by selected backend:
-  - `codex` → `@codex review`
-  - `gemini` → `/gemini review`
-  - `claude` → `@claude review once` (already handled)
-- add a same-head dedupe guard: before posting the trigger comment,
-  check existing PR comments for a matching trigger body that targets
-  the current head SHA within the last 30 minutes; skip posting if
-  one already exists
-- keep existing Gemini-specific note in place — Gemini already uses
-  `trigger_mode=comment`, the new change only generalizes Codex to the
-  same path
+  - `workflow_dispatch` runs respect `inputs.trigger_mode` (defaults
+    to `skip`)
+  - Codex stays on `trigger_mode=skip` with an inline comment noting
+    that Codex Cloud rejects bot-posted triggers
+  - Claude stays on `trigger_mode=skip` because `claude-review.yml`
+    gates on trusted-author issue_comment events
+  - Gemini (the only backend that accepts bot-posted triggers on
+    `synchronize`) falls through to `trigger_mode=comment`
+- `scripts/ai-review-gate.mjs` already picks the trigger comment text
+  by selected backend via `buildTriggerComment()`; no changes there
+- add a same-head dedupe guard in `ensureTriggerComment()`: before
+  posting a Gemini trigger comment, look for an existing gate comment
+  with the current head SHA's `metadataMarker` within the last 30
+  minutes; reuse the existing comment instead of posting a duplicate
 
 ## Slice 3: Fallback helper `scripts/switch-review-agent.mjs`
 

--- a/specs/005-ai-review-auto-retrigger-and-fallback/plan.md
+++ b/specs/005-ai-review-auto-retrigger-and-fallback/plan.md
@@ -8,22 +8,31 @@
 
 ## Slice 2: Document constraints and collapse workflow policy to skip
 
-- rewrite the `Resolve selected review policy` step in
-  `.github/workflows/ai-review.yml` so every `pull_request` event
-  resolves `trigger_mode=skip`, regardless of the selected backend.
-  Keep `workflow_dispatch` runs honoring `inputs.trigger_mode`
-  (default `skip`) so manual dispatches can still opt into comment
-  mode for future backends that support bot triggers.
-- inline comments in the workflow enumerate the per-backend reason
-  (Codex rejects, Gemini ignores, Claude gates on human author) and
-  link to
+- the `Resolve selected review policy` step in
+  `.github/workflows/ai-review.yml` now resolves `trigger_mode=skip`
+  on every `pull_request` event regardless of the selected backend.
+  No backend-specific branches exist in the `pull_request` path.
+  `workflow_dispatch` runs continue to honor `inputs.trigger_mode`
+  (defaulting to `skip`), so manual dispatches remain the only way
+  to reach `trigger_mode=comment` and they are not wired to any of
+  the current backends.
+- inline comments in the workflow file enumerate the per-backend
+  reason (Codex rejects, Gemini silently ignores, Claude gates on
+  human author) and cross-reference
   `docs_dreamboard/project/devops/ai-runner.md` §Backend Trigger
   Constraints.
-- `scripts/ai-review-gate.mjs` already picks the trigger comment text
-  by selected backend via `buildTriggerComment()`; no changes there
-  beyond the 30-minute same-head dedupe guard in
-  `ensureTriggerComment()`, which protects against duplicate trigger
-  comments on repeated manual dispatches for the same head SHA.
+- `scripts/ai-review-gate.mjs` keeps `buildTriggerComment()` for the
+  Codex and Gemini branches (reachable only via the explicit
+  `workflow_dispatch` comment-mode entry point), and now throws on
+  the Claude branch so a future misconfiguration surfaces as a loud
+  error instead of a silently ignored bot comment.
+- `ensureTriggerComment()` carries a 30-minute same-head dedupe
+  guard: it reuses an existing gate-authored trigger comment (by
+  hidden `metadataMarker`) **or** a trusted human comment that
+  already carries the bare backend trigger keyword
+  (`@codex review` / `/gemini review` / `@claude review once`),
+  excluding comments authored by any of the reviewer bots
+  themselves.
 
 ## Slice 3: Fallback helper `scripts/switch-review-agent.mjs`
 

--- a/specs/005-ai-review-auto-retrigger-and-fallback/spec.md
+++ b/specs/005-ai-review-auto-retrigger-and-fallback/spec.md
@@ -19,15 +19,18 @@ review once`. Gemini is the exception because its PR-linked path already
 
 - Update `.github/workflows/ai-review.yml` so that on
   `pull_request: synchronize` events (and `opened` / `reopened` /
-  `ready_for_review`) the gate posts a native trigger comment for the
-  selected reviewer, including Codex. Current behavior uses
-  `trigger_mode=skip` for Codex, which prevents automatic re-review on
-  new commits.
+  `ready_for_review`) the gate posts `/gemini review` for the current
+  head SHA when `AI_REVIEW_AGENT=gemini`. Codex auto-retrigger on
+  `synchronize` is explicitly out of scope: Codex Cloud rejects
+  bot-posted `@codex review` triggers ("trigger did not come from a
+  connected human Codex account"), so the gate keeps
+  `trigger_mode=skip` for Codex and we document the manual recovery
+  path. Claude review stays human-initiated only for the same reason.
 - Preserve the existing `manual command → native-only` contract:
   trusted `@codex review` / `/gemini review` / `@claude review once`
   comments posted by humans must NOT be canceled by the auto-trigger.
-  Deduplicate by same-head check so the gate does not spam multiple
-  trigger comments for the same SHA.
+  Deduplicate Gemini trigger comments by same-head check so the gate
+  does not spam multiple trigger comments for the same SHA.
 - Add a small repository helper `scripts/switch-review-agent.mjs` that
   takes `--to <codex|gemini|claude>` and performs: (a)
   `gh variable set AI_REVIEW_AGENT --body <agent>`, (b) posts the
@@ -53,6 +56,10 @@ review once`. Gemini is the exception because its PR-linked path already
   / Claude findings; only the trigger behavior changes.
 - No automatic detection of rate-limit errors — fallback is still
   human-initiated through the helper, not automatic.
+- No Codex auto-retrigger on `synchronize`. Codex Cloud's
+  human-account requirement on review triggers cannot be satisfied
+  from a GitHub Actions workflow without a user PAT, which is not in
+  scope for this spec.
 - No Playwright or e2e test infrastructure.
 - No changes to `.gemini/config.yaml` or `.gemini/styleguide.md`; the
   existing Gemini review configuration is already correct for this
@@ -60,15 +67,15 @@ review once`. Gemini is the exception because its PR-linked path already
 
 ## Acceptance Criteria
 
-1. After a push to `fix/ai-review-auto-retrigger-and-fallback` that
-   lands a new head SHA on an open PR, the `AI Review` workflow run
-   posts a single native trigger comment for the selected reviewer
-   (`@codex review` for Codex, `/gemini review` for Gemini,
-   `@claude review once` for Claude) within one run, without any human
-   action.
-2. If a trusted human comment already triggered a native review for the
-   current head SHA, the workflow does not post a duplicate trigger
-   comment on the same SHA during the automatic retrigger path.
+1. After a push that lands a new head SHA on an open PR with
+   `AI_REVIEW_AGENT=gemini`, the `AI Review` workflow run posts a
+   single `/gemini review` trigger comment for the current head SHA
+   without any human action. Codex and Claude paths remain
+   `trigger_mode=skip` by design.
+2. If a trusted human comment already triggered a native Gemini review
+   for the current head SHA within the last 30 minutes, the workflow
+   does not post a duplicate trigger comment on the same SHA during
+   the automatic retrigger path.
 3. `scripts/switch-review-agent.mjs --to <agent>` flips
    `AI_REVIEW_AGENT` via `gh variable set`, posts the correct native
    trigger comment on the current branch's open PR (resolved via

--- a/specs/005-ai-review-auto-retrigger-and-fallback/spec.md
+++ b/specs/005-ai-review-auto-retrigger-and-fallback/spec.md
@@ -1,36 +1,49 @@
-# Spec: auto-retrigger native review on synchronize and one-command fallback
+# Spec: document review backend trigger constraints and ship a one-command fallback
 
 ## Goal
 
-Stop losing PR time on two operational frictions observed on PR #9:
+Stop losing PR time on two operational frictions observed on PR #9 and
+confirmed on PR #10:
 
-1. Pushing a new commit to an open PR does not auto-retrigger the selected
-   native reviewer (Codex, Claude), so the `AI Review` gate passively polls
-   and times out until a human manually posts `@codex review` / `@claude
-review once`. Gemini is the exception because its PR-linked path already
-   posts a trigger comment.
+1. **Auto-retrigger of native review on `synchronize` is not achievable
+   from a stock GitHub Actions workflow.** All three supported review
+   backends reject bot-authored trigger comments: Codex Cloud fails
+   fast with "trigger did not come from a connected human Codex
+   account", Gemini Code Assist silently ignores bot-posted
+   `/gemini review`, and `claude-review.yml` gates on trusted
+   `author_association`. This is documented once in durable docs so
+   the next repo that adopts this pattern does not rediscover it the
+   hard way.
 
-2. When the selected review backend is unavailable (rate limits, app outage,
-   unexpected silence), switching to a fallback backend requires three manual
-   steps (`gh variable set`, `gh pr comment`, `gh run rerun --failed`) and
-   institutional memory of which command to use for which backend.
+2. When the selected review backend is unavailable (rate limits, app
+   outage, unexpected silence), switching to a fallback backend
+   requires three manual steps (`gh variable set`, `gh pr comment`,
+   `gh run rerun --failed`) and institutional memory of which command
+   to use for which backend. Ship a single-command helper that does
+   all three as the current `gh` user (so the trigger comment is
+   human-authored and therefore trusted).
 
 ## Scope
 
-- Update `.github/workflows/ai-review.yml` so that on
-  `pull_request: synchronize` events (and `opened` / `reopened` /
-  `ready_for_review`) the gate posts `/gemini review` for the current
-  head SHA when `AI_REVIEW_AGENT=gemini`. Codex auto-retrigger on
-  `synchronize` is explicitly out of scope: Codex Cloud rejects
-  bot-posted `@codex review` triggers ("trigger did not come from a
-  connected human Codex account"), so the gate keeps
-  `trigger_mode=skip` for Codex and we document the manual recovery
-  path. Claude review stays human-initiated only for the same reason.
-- Preserve the existing `manual command → native-only` contract:
-  trusted `@codex review` / `/gemini review` / `@claude review once`
-  comments posted by humans must NOT be canceled by the auto-trigger.
-  Deduplicate Gemini trigger comments by same-head check so the gate
-  does not spam multiple trigger comments for the same SHA.
+- Collapse the `Resolve selected review policy` step in
+  `.github/workflows/ai-review.yml` so that every `pull_request` event
+  sets `trigger_mode=skip` regardless of the selected backend. Inline
+  comments in the workflow enumerate the reason per backend (Codex
+  rejects, Gemini ignores, Claude gates on human author_association)
+  and link to the constraint table in durable docs.
+- Keep `trigger_mode=comment` reachable only via `workflow_dispatch`
+  with an explicit `inputs.trigger_mode=comment`, so the
+  `ensureTriggerComment` code path remains available for manual
+  dispatches and for future backends that accept bot-posted triggers.
+- Keep the 30-minute same-head dedupe guard in `ensureTriggerComment`
+  so repeated manual dispatches on the same head SHA reuse the
+  existing trigger comment instead of spamming the PR.
+- Document the constraint matrix in
+  `docs_dreamboard/project/devops/ai-runner.md` (§Backend Trigger
+  Constraints) and
+  `docs_dreamboard/project/devops/review-contract.md` (§Backend
+  Trigger Constraints). Cross-link from
+  `docs_dreamboard/project/devops/ai-pr-workflow.md`.
 - Add a small repository helper `scripts/switch-review-agent.mjs` that
   takes `--to <codex|gemini|claude>` and performs: (a)
   `gh variable set AI_REVIEW_AGENT --body <agent>`, (b) posts the
@@ -56,10 +69,12 @@ review once`. Gemini is the exception because its PR-linked path already
   / Claude findings; only the trigger behavior changes.
 - No automatic detection of rate-limit errors — fallback is still
   human-initiated through the helper, not automatic.
-- No Codex auto-retrigger on `synchronize`. Codex Cloud's
-  human-account requirement on review triggers cannot be satisfied
-  from a GitHub Actions workflow without a user PAT, which is not in
-  scope for this spec.
+- No auto-retrigger of native review on `synchronize` for any
+  backend. All three reject bot-authored triggers (Codex fails fast,
+  Gemini silently ignores, Claude gates on trusted
+  `author_association`), and bypassing this would require either a
+  user PAT in repository secrets or a dedicated service account with
+  trusted author_association. Both are out of scope.
 - No Playwright or e2e test infrastructure.
 - No changes to `.gemini/config.yaml` or `.gemini/styleguide.md`; the
   existing Gemini review configuration is already correct for this
@@ -67,15 +82,15 @@ review once`. Gemini is the exception because its PR-linked path already
 
 ## Acceptance Criteria
 
-1. After a push that lands a new head SHA on an open PR with
-   `AI_REVIEW_AGENT=gemini`, the `AI Review` workflow run posts a
-   single `/gemini review` trigger comment for the current head SHA
-   without any human action. Codex and Claude paths remain
-   `trigger_mode=skip` by design.
-2. If a trusted human comment already triggered a native Gemini review
-   for the current head SHA within the last 30 minutes, the workflow
-   does not post a duplicate trigger comment on the same SHA during
-   the automatic retrigger path.
+1. On every `pull_request` event (regardless of
+   `AI_REVIEW_AGENT`), the `Resolve selected review policy` step in
+   `.github/workflows/ai-review.yml` resolves `trigger_mode=skip` and
+   the gate does not post any trigger comment. Inline comments in the
+   workflow file enumerate the per-backend reason.
+2. When the gate is dispatched via `workflow_dispatch` with
+   `inputs.trigger_mode=comment` and a trigger comment for the
+   current head SHA already exists within the last 30 minutes, the
+   gate reuses the existing comment instead of posting a duplicate.
 3. `scripts/switch-review-agent.mjs --to <agent>` flips
    `AI_REVIEW_AGENT` via `gh variable set`, posts the correct native
    trigger comment on the current branch's open PR (resolved via

--- a/specs/005-ai-review-auto-retrigger-and-fallback/spec.md
+++ b/specs/005-ai-review-auto-retrigger-and-fallback/spec.md
@@ -1,0 +1,91 @@
+# Spec: auto-retrigger native review on synchronize and one-command fallback
+
+## Goal
+
+Stop losing PR time on two operational frictions observed on PR #9:
+
+1. Pushing a new commit to an open PR does not auto-retrigger the selected
+   native reviewer (Codex, Claude), so the `AI Review` gate passively polls
+   and times out until a human manually posts `@codex review` / `@claude
+review once`. Gemini is the exception because its PR-linked path already
+   posts a trigger comment.
+
+2. When the selected review backend is unavailable (rate limits, app outage,
+   unexpected silence), switching to a fallback backend requires three manual
+   steps (`gh variable set`, `gh pr comment`, `gh run rerun --failed`) and
+   institutional memory of which command to use for which backend.
+
+## Scope
+
+- Update `.github/workflows/ai-review.yml` so that on
+  `pull_request: synchronize` events (and `opened` / `reopened` /
+  `ready_for_review`) the gate posts a native trigger comment for the
+  selected reviewer, including Codex. Current behavior uses
+  `trigger_mode=skip` for Codex, which prevents automatic re-review on
+  new commits.
+- Preserve the existing `manual command → native-only` contract:
+  trusted `@codex review` / `/gemini review` / `@claude review once`
+  comments posted by humans must NOT be canceled by the auto-trigger.
+  Deduplicate by same-head check so the gate does not spam multiple
+  trigger comments for the same SHA.
+- Add a small repository helper `scripts/switch-review-agent.mjs` that
+  takes `--to <codex|gemini|claude>` and performs: (a)
+  `gh variable set AI_REVIEW_AGENT --body <agent>`, (b) posts the
+  appropriate native trigger comment on the current branch's open PR,
+  (c) reruns the failed `AI Review` job for the latest head SHA on that
+  PR. Expose as `pnpm run review:switch -- --to gemini`.
+- Document the auto-retrigger behavior and the fallback helper in
+  `docs_dreamboard/project/devops/ai-runner.md`,
+  `docs_dreamboard/project/devops/ai-pr-workflow.md`, and
+  `docs_dreamboard/project/devops/macos-local-runners.md`.
+- Add `.omc/` to `.gitignore` as housekeeping (oh-my-claudecode local
+  state directory that was leaking as untracked on every branch).
+- Track the change in `specs/005-ai-review-auto-retrigger-and-fallback/`
+  with `spec.md`, `plan.md`, and `tasks.md`.
+
+## Non-Goals
+
+- No changes to application behavior in `index.html` or `src/`.
+- No changes to Vercel configuration or Vercel dashboard settings.
+- No rename of the required check names (`baseline-checks`, `guard`,
+  `AI Review`) or the `AI_REVIEW_OUTCOME` header schema.
+- No changes to the `ai-review-gate.mjs` scoring rules for Codex / Gemini
+  / Claude findings; only the trigger behavior changes.
+- No automatic detection of rate-limit errors — fallback is still
+  human-initiated through the helper, not automatic.
+- No Playwright or e2e test infrastructure.
+- No changes to `.gemini/config.yaml` or `.gemini/styleguide.md`; the
+  existing Gemini review configuration is already correct for this
+  repository and is not in scope.
+
+## Acceptance Criteria
+
+1. After a push to `fix/ai-review-auto-retrigger-and-fallback` that
+   lands a new head SHA on an open PR, the `AI Review` workflow run
+   posts a single native trigger comment for the selected reviewer
+   (`@codex review` for Codex, `/gemini review` for Gemini,
+   `@claude review once` for Claude) within one run, without any human
+   action.
+2. If a trusted human comment already triggered a native review for the
+   current head SHA, the workflow does not post a duplicate trigger
+   comment on the same SHA during the automatic retrigger path.
+3. `scripts/switch-review-agent.mjs --to <agent>` flips
+   `AI_REVIEW_AGENT` via `gh variable set`, posts the correct native
+   trigger comment on the current branch's open PR (resolved via
+   `gh pr view --json number`), and reruns the most recent failed
+   `AI Review` job on that PR.
+4. `pnpm run review:switch -- --to <agent>` invokes the helper and
+   exits with code 0 on success.
+5. `docs_dreamboard/project/devops/ai-runner.md` and
+   `docs_dreamboard/project/devops/ai-pr-workflow.md` describe the
+   auto-retrigger step explicitly, and
+   `docs_dreamboard/project/devops/macos-local-runners.md` documents
+   the fallback helper with an example invocation.
+6. `.gitignore` contains `.omc/`, and the repository working tree no
+   longer reports `.omc/` as untracked in `git status`.
+7. `specs/005-ai-review-auto-retrigger-and-fallback/{spec,plan,tasks}.md`
+   exists and the feature-memory gate passes on the PR head SHA via
+   `node scripts/check-feature-memory.mjs --worktree`.
+8. `baseline-checks`, `guard`, `AI Review`, and the Vercel preview are
+   green on the PR head SHA, without a human having to post a manual
+   review trigger after the first push.

--- a/specs/005-ai-review-auto-retrigger-and-fallback/tasks.md
+++ b/specs/005-ai-review-auto-retrigger-and-fallback/tasks.md
@@ -6,9 +6,8 @@
 
 ## Slice 2 — Auto-retrigger
 
-- [ ] Update `.github/workflows/ai-review.yml` `Resolve selected review policy` step to set `trigger_mode=comment` for Codex on `pull_request` events (keep `skip` only for `workflow_dispatch` with explicit `inputs.trigger_mode=skip`)
-- [ ] Teach `scripts/ai-review-gate.mjs` to pick the trigger comment text by selected backend (`@codex review` / `/gemini review` / `@claude review once`)
-- [ ] Add same-head dedupe guard in the gate so it does not post a duplicate trigger comment when a trusted human comment for the current head SHA already exists
+- [ ] Update `.github/workflows/ai-review.yml` `Resolve selected review policy` step to set `trigger_mode=comment` for Gemini only on `pull_request` events; keep `skip` for Codex (bot triggers rejected by Codex Cloud) and Claude (`claude-review.yml` gates on trusted-author events)
+- [ ] Add same-head dedupe guard in `ensureTriggerComment()` so Gemini trigger comments are reused when the current head SHA marker already exists within the last 30 minutes
 
 ## Slice 3 — Fallback helper
 

--- a/specs/005-ai-review-auto-retrigger-and-fallback/tasks.md
+++ b/specs/005-ai-review-auto-retrigger-and-fallback/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+## Slice 1 — Housekeeping
+
+- [ ] Add `.omc/` entry to `.gitignore`
+
+## Slice 2 — Auto-retrigger
+
+- [ ] Update `.github/workflows/ai-review.yml` `Resolve selected review policy` step to set `trigger_mode=comment` for Codex on `pull_request` events (keep `skip` only for `workflow_dispatch` with explicit `inputs.trigger_mode=skip`)
+- [ ] Teach `scripts/ai-review-gate.mjs` to pick the trigger comment text by selected backend (`@codex review` / `/gemini review` / `@claude review once`)
+- [ ] Add same-head dedupe guard in the gate so it does not post a duplicate trigger comment when a trusted human comment for the current head SHA already exists
+
+## Slice 3 — Fallback helper
+
+- [ ] Create `scripts/switch-review-agent.mjs` with `--to`, optional `--pr`, optional `--rerun` (default true)
+- [ ] Wire steps: `gh variable set AI_REVIEW_AGENT --body <agent>` → `gh pr comment <pr> --body <trigger>` → `gh run rerun <id> --failed`
+- [ ] Add `review:switch` script to `package.json`
+
+## Slice 4 — Documentation
+
+- [ ] Update `docs_dreamboard/project/devops/ai-runner.md` Review Gate section with the auto-retrigger behavior
+- [ ] Update `docs_dreamboard/project/devops/ai-pr-workflow.md` Review Contract section to remove the manual `@codex review` step
+- [ ] Add a "Fallback review agent" subsection to `docs_dreamboard/project/devops/macos-local-runners.md` with `pnpm run review:switch -- --to gemini` example
+
+## Slice 5 — Validation
+
+- [ ] `pnpm run ci` inside the worktree
+- [ ] `node scripts/check-feature-memory.mjs --worktree`
+- [ ] Push a whitespace commit and confirm auto-retrigger works without manual intervention
+- [ ] Dry-run `pnpm run review:switch -- --to gemini` and confirm variable flip + trigger comment + rerun
+- [ ] Open PR, wait for `baseline-checks`, `guard`, `AI Review`, and Vercel preview to be green on the same head SHA

--- a/specs/005-ai-review-auto-retrigger-and-fallback/tasks.md
+++ b/specs/005-ai-review-auto-retrigger-and-fallback/tasks.md
@@ -6,8 +6,8 @@
 
 ## Slice 2 — Auto-retrigger
 
-- [ ] Update `.github/workflows/ai-review.yml` `Resolve selected review policy` step to set `trigger_mode=comment` for Gemini only on `pull_request` events; keep `skip` for Codex (bot triggers rejected by Codex Cloud) and Claude (`claude-review.yml` gates on trusted-author events)
-- [ ] Add same-head dedupe guard in `ensureTriggerComment()` so Gemini trigger comments are reused when the current head SHA marker already exists within the last 30 minutes
+- [ ] Collapse `.github/workflows/ai-review.yml` `Resolve selected review policy` step so every `pull_request` event resolves `trigger_mode=skip`, with inline comments enumerating the per-backend reason (Codex rejects, Gemini ignores, Claude gates on human author)
+- [ ] Keep the same-head dedupe guard in `ensureTriggerComment()` so explicit `workflow_dispatch` runs with `inputs.trigger_mode=comment` do not post duplicate triggers for the same head SHA
 
 ## Slice 3 — Fallback helper
 
@@ -17,8 +17,9 @@
 
 ## Slice 4 — Documentation
 
-- [ ] Update `docs_dreamboard/project/devops/ai-runner.md` Review Gate section with the auto-retrigger behavior
-- [ ] Update `docs_dreamboard/project/devops/ai-pr-workflow.md` Review Contract section to remove the manual `@codex review` step
+- [ ] Add `§Backend Trigger Constraints` section to `docs_dreamboard/project/devops/ai-runner.md` with the full backend × event matrix
+- [ ] Add `§Backend Trigger Constraints` section to `docs_dreamboard/project/devops/review-contract.md` summarizing the finding
+- [ ] Update `docs_dreamboard/project/devops/ai-pr-workflow.md` Review Contract section to state that no backend auto-retriggers on `synchronize` and document the `pnpm run review:switch` recovery path
 - [ ] Add a "Fallback review agent" subsection to `docs_dreamboard/project/devops/macos-local-runners.md` with `pnpm run review:switch -- --to gemini` example
 
 ## Slice 5 — Validation


### PR DESCRIPTION
## Summary

- **Empirical finding, now documented**: none of the three supported review backends (Codex, Gemini, Claude) accept bot-authored trigger comments on `pull_request: synchronize` events. Codex Cloud fails fast with "trigger did not come from a connected human Codex account", Gemini Code Assist silently ignores bot-posted `/gemini review`, and `claude-review.yml` gates on trusted `author_association` and drops bot comments. Auto-retrigger of native review on synchronize is therefore not achievable from a stock GitHub Actions workflow.
- **Workflow collapses to `trigger_mode=skip`** on every `pull_request` event with inline comments explaining the per-backend reason. Codex Cloud's on-open auto-review still covers the initial review for free.
- **New fallback helper**: `pnpm run review:switch -- --to <codex|gemini|claude>` does one-shot `gh variable set` + human-authored trigger comment + rerun of the failed / timed-out / cancelled `AI Review` run. Human-authored trigger because the helper uses the current `gh` user identity, which all three backends accept.
- **Durable docs**: new §Backend Trigger Constraints section in `docs_dreamboard/project/devops/ai-runner.md` and `docs_dreamboard/project/devops/review-contract.md` with the full backend × event × accepts-bot-trigger × recovery-path matrix. This is the setup guidance to copy to any future repository adopting this AI review pattern.
- **Housekeeping**: `.omc/` added to `.gitignore` so the oh-my-claudecode local state stops leaking as untracked on every branch.
- Tracked in \`specs/005-ai-review-auto-retrigger-and-fallback/{spec,plan,tasks}.md\`.

## Test plan

- [x] \`pnpm run ci\` green locally (check:repo, check:html, build, format:check)
- [x] \`node scripts/check-feature-memory.mjs --worktree\` passes
- [x] Manual empirical test on PR #10: bot-posted \`/gemini review\` times out after 20m (confirming Gemini also rejects bot triggers); human-posted \`/gemini review\` returns a review within ~1 minute (confirming baseline works)
- [ ] \`baseline-checks\`, \`guard\`, \`AI Review\`, Vercel preview green on the PR head SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)