### PR TITLE
fix(security): pin gate script execution to default branch

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -54,9 +54,14 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Checkout
+      # Pin checkout to default branch so gate scripts (resolve-pr-context.mjs,
+      # ai-review-gate.mjs) execute from trusted main instead of the PR head.
+      # Without this a contributor could patch scripts/ in their PR to bypass
+      # the required AI Review check.
+      - name: Checkout trusted base (default branch)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
 
       - name: Resolve PR context

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -32,23 +32,25 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      # Two-checkout pattern: trusted gate scripts come from main, PR tree is
-      # available in the workspace root for diff and filesystem checks.
-      # Without this a contributor could tamper with scripts/ in their PR to
-      # bypass required PR Guard checks.
+      # Two-checkout pattern: PR content lives in workspace root for diff and
+      # filesystem checks; trusted gate scripts come from main into a sub-path.
+      # Order matters: actions/checkout v6 wipes workspace root if it sees a
+      # non-empty directory without a matching .git, so PR must check out
+      # first while workspace is empty. The trusted sub-path checkout always
+      # ends with main's content even if the PR seeds an adversarial
+      # .gate-trusted/, because actions/checkout reinitializes the path.
+      - name: Checkout PR content
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+
       - name: Checkout trusted gate scripts (default branch)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.repository.default_branch }}
           path: .gate-trusted
           fetch-depth: 1
-
-      - name: Checkout PR content
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
-          clean: false
 
       - name: Resolve diff refs
         shell: bash

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -32,11 +32,23 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Checkout
+      # Two-checkout pattern: trusted gate scripts come from main, PR tree is
+      # available in the workspace root for diff and filesystem checks.
+      # Without this a contributor could tamper with scripts/ in their PR to
+      # bypass required PR Guard checks.
+      - name: Checkout trusted gate scripts (default branch)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: .gate-trusted
+          fetch-depth: 1
+
+      - name: Checkout PR content
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+          clean: false
 
       - name: Resolve diff refs
         shell: bash
@@ -105,7 +117,7 @@ jobs:
           echo "Docs coverage OK."
 
       - name: Require complete feature memory for product changes
-        run: node scripts/check-feature-memory.mjs "$BASE_REF" "$HEAD_REF"
+        run: node .gate-trusted/scripts/check-feature-memory.mjs "$BASE_REF" "$HEAD_REF"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -120,4 +132,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Validate baseline files
-        run: pnpm run check:repo
+        run: node .gate-trusted/scripts/check-static-baseline.mjs

--- a/docs_dreamboard/project/devops/ai-pr-workflow.md
+++ b/docs_dreamboard/project/devops/ai-pr-workflow.md
@@ -38,6 +38,12 @@ This is the canonical PR loop for `dreamboard`.
 - If the selected implementation agent path is unavailable, stop and report the
   blocker instead of bypassing the loop.
 - A PR is not done while required checks are queued, running, or red.
+- Gate scripts (`scripts/check-feature-memory.mjs`,
+  `scripts/check-static-baseline.mjs`, `scripts/resolve-pr-context.mjs`,
+  `scripts/ai-review-gate.mjs`) execute only from `default_branch` via
+  `actions/checkout` with explicit `ref:`. PR Guard uses a two-checkout pattern
+  (`.gate-trusted/` for trusted scripts, workspace root for PR content), so a
+  PR cannot tamper with gate logic to bypass required checks.
 
 ## Review Contract
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,3 @@
 minimumReleaseAge: 10080
+packages:
+  - .

--- a/specs/010-fix-pr-ref-gate-scripts/plan.md
+++ b/specs/010-fix-pr-ref-gate-scripts/plan.md
@@ -1,0 +1,76 @@
+# Plan 010: Fix PR-ref gate scripts
+
+## Approach
+
+Один PR, один коммит. Параллель с фиксом, который уже приземлился в
+tone-of-voice репо. Затрагиваем только два workflow-файла плюс обязательные
+spec-файлы и заметка в `ai-pr-workflow.md`.
+
+## Changes
+
+### F1 — `.github/workflows/ai-review.yml`
+
+Один checkout, явный `ref`:
+
+```yaml
+- name: Checkout trusted base (default branch)
+  uses: actions/checkout@de0fac2e... # v6
+  with:
+    ref: ${{ github.event.repository.default_branch }}
+    fetch-depth: 1
+```
+
+Inline-комментарий объясняет threat model для будущих читателей.
+
+### F2 — `.github/workflows/pr-guard.yml`
+
+Two-checkout:
+
+```yaml
+- name: Checkout trusted gate scripts (default branch)
+  uses: actions/checkout@de0fac2e... # v6
+  with:
+    ref: ${{ github.event.repository.default_branch }}
+    path: .gate-trusted
+    fetch-depth: 1
+
+- name: Checkout PR content
+  uses: actions/checkout@de0fac2e... # v6
+  with:
+    fetch-depth: 0
+    ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+    clean: false
+```
+
+Порядок важен: trusted сначала, PR с `clean: false` вторым. Если бы PR шёл
+первым, второй checkout из main мог бы быть уязвим к adversarial
+`.gate-trusted/.git/` в PR-tree. Если бы PR шёл вторым с `clean: true`,
+`git clean -ffdx` снёс бы `.gate-trusted/`.
+
+Замена двух запусков скриптов:
+
+- `node scripts/check-feature-memory.mjs` →
+  `node .gate-trusted/scripts/check-feature-memory.mjs`
+- `pnpm run check:repo` → `node .gate-trusted/scripts/check-static-baseline.mjs`
+
+`process.cwd()` обоих скриптов остаётся workspace root (PR-tree), поэтому
+`existsSync` проверяет PR-овское состояние, а не main.
+
+`pnpm install --frozen-lockfile` остаётся как есть: pnpm-binary доверенный
+(SHA-pinned), а валидация PR-овского lockfile — это и есть цель.
+
+### F3 — `docs_dreamboard/project/devops/ai-pr-workflow.md`
+
+В секцию `## Hard Gates` добавить пункт о trusted-base pattern: gate-скрипты
+исполняются только из main, не из PR.
+
+## Risks
+
+- Этот PR может не пройти свой собственный `guard`, потому что workflow в
+  PR пока работает по старой схеме на `pull_request` event. На самом деле
+  no — для same-repo PR GitHub Actions берёт workflow-файл из PR head, так
+  что новый pattern активируется сразу. Проверим в run.
+- Если `.gate-trusted/` чекаут падает (network), PR не сможет пройти guard.
+  Mitigation: `actions/checkout` retries на 401/5xx из коробки.
+- `node` без `setup-node` доступен на ubuntu-latest из коробки (preinstalled
+  через nvm). Проверено.

--- a/specs/010-fix-pr-ref-gate-scripts/plan.md
+++ b/specs/010-fix-pr-ref-gate-scripts/plan.md
@@ -27,25 +27,34 @@ Inline-комментарий объясняет threat model для будущ�
 Two-checkout:
 
 ```yaml
+- name: Checkout PR content
+  uses: actions/checkout@de0fac2e... # v6
+  with:
+    fetch-depth: 0
+    ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+
 - name: Checkout trusted gate scripts (default branch)
   uses: actions/checkout@de0fac2e... # v6
   with:
     ref: ${{ github.event.repository.default_branch }}
     path: .gate-trusted
     fetch-depth: 1
-
-- name: Checkout PR content
-  uses: actions/checkout@de0fac2e... # v6
-  with:
-    fetch-depth: 0
-    ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
-    clean: false
 ```
 
-Порядок важен: trusted сначала, PR с `clean: false` вторым. Если бы PR шёл
-первым, второй checkout из main мог бы быть уязвим к adversarial
-`.gate-trusted/.git/` в PR-tree. Если бы PR шёл вторым с `clean: true`,
-`git clean -ffdx` снёс бы `.gate-trusted/`.
+Порядок важен: PR-content first, trusted second. `actions/checkout` v6 при
+checkout в непустую директорию без matching `.git/` делает
+`Deleting the contents of '<path>'` — это `prepareExistingDirectory()`,
+fires до `clean` фазы и не блокируется `clean: false`. Если бы trusted шёл
+первым, второй checkout на workspace root снёс бы `.gate-trusted/` (как и
+случилось в первой попытке этого фикса, GH run 25027611454).
+
+Adversarial `.gate-trusted/` в PR-tree не страшен: второй checkout с
+`path: .gate-trusted` вызывает `prepareExistingDirectory()` для подпапки,
+который stomps non-matching content и переинициализирует с main. Даже если
+PR засеет `.gate-trusted/.git/` с фальшивым origin URL, action всё равно
+делает rm-rf и init заново. Если PR попадает в матчинг origin, `git fetch`
+пуллит реальный main (token-аутентифицированный), коллизию SHA подделать
+нельзя.
 
 Замена двух запусков скриптов:
 

--- a/specs/010-fix-pr-ref-gate-scripts/spec.md
+++ b/specs/010-fix-pr-ref-gate-scripts/spec.md
@@ -1,0 +1,70 @@
+# Spec 010: Fix PR-ref gate scripts
+
+## Problem
+
+Audit в параллельной сессии (tone-of-voice) выявил тот же класс уязвимости в
+dreamboard. `actions/checkout` в `pr-guard.yml` и `ai-review.yml` тянет
+workspace по PR-ref, а gate-скрипты (`scripts/check-feature-memory.mjs`,
+`scripts/resolve-pr-context.mjs`, `scripts/ai-review-gate.mjs`) выполняются
+именно из этого untrusted workspace.
+
+Вектор: контрибьютор подменяет gate-скрипт в своём PR (например,
+`scripts/check-feature-memory.mjs` → `process.exit(0)`) и проходит required
+check без реальной проверки.
+
+Затронутые required checks: `guard`, `ai-review`. `baseline-checks` (CI)
+запускается на PR-ref сознательно (валидирует PR), но `pnpm run check:repo`
+внутри `guard` тоже резолвится через PR-овский `package.json`, что делает
+его tamper-prone.
+
+## Goal
+
+Закрыть P0 уязвимость одним PR. Gate-скрипты обязаны исполняться только из
+trusted main, при этом сохраняя возможность валидировать содержимое PR
+(diff, новые файлы в `specs/<id>/`, baseline).
+
+## Scope
+
+### F1 — `ai-review.yml`: checkout по default_branch
+
+Single checkout с явным `ref: ${{ github.event.repository.default_branch }}`.
+Скрипты `resolve-pr-context.mjs` и `ai-review-gate.mjs` не зависят от
+filesystem PR-а — они читают PR-контекст через `GITHUB_EVENT_PATH` и GitHub
+API, поэтому одной проверки main достаточно.
+
+### F2 — `pr-guard.yml`: two-checkout pattern
+
+Trusted main в `.gate-trusted/`, PR в workspace root. Это нужно потому,
+что `check-feature-memory.mjs` помимо `git diff` ещё проверяет
+`existsSync(specs/<id>/spec.md)` — для новых файлов в PR требуется PR-овское
+дерево на диске.
+
+PR-checkout получает `clean: false`, чтобы `git clean -ffdx` не уничтожил
+`.gate-trusted/` после первой стадии.
+
+`node scripts/check-feature-memory.mjs "$BASE_REF" "$HEAD_REF"` →
+`node .gate-trusted/scripts/check-feature-memory.mjs "$BASE_REF" "$HEAD_REF"`.
+`pnpm run check:repo` → `node .gate-trusted/scripts/check-static-baseline.mjs`
+(минует PR-овский `package.json`, но `process.cwd()` остаётся на PR-tree).
+
+## Out of scope
+
+- Inline shell в `pr-guard.yml` (docs coverage check) — tamper-prone
+  через изменение workflow-файла, отдельный класс защиты (branch protection
+  на `.github/workflows/`, code review).
+- `pnpm install --frozen-lockfile` — это валидатор lockfile, а не gate-скрипт;
+  pnpm-binary доверенный (SHA-pinned action).
+- `--ignore-scripts` для `pnpm install` — отдельная supply-chain hardening.
+- `osv-scan.yml` — сознательно сканирует PR-овский lockfile.
+- `ci.yml` baseline-checks — пока сознательно запускается на PR-tree
+  (валидирует PR build).
+
+## Acceptance
+
+- `pnpm run preflight` зелёный локально
+- `guard` зелёный на этом PR (использует trusted gate из main, который
+  валидирует PR-tree через `git diff` и `existsSync`)
+- `ai-review` зелёный (использует trusted scripts/ из main для polling)
+- Контрибьютор больше не может пройти `guard`/`ai-review` через изменение
+  `scripts/check-feature-memory.mjs`, `scripts/check-static-baseline.mjs`,
+  `scripts/resolve-pr-context.mjs` или `scripts/ai-review-gate.mjs` в PR

--- a/specs/010-fix-pr-ref-gate-scripts/spec.md
+++ b/specs/010-fix-pr-ref-gate-scripts/spec.md
@@ -59,6 +59,17 @@ PR-checkout получает `clean: false`, чтобы `git clean -ffdx` не �
 - `ci.yml` baseline-checks — пока сознательно запускается на PR-tree
   (валидирует PR build).
 
+## Defensive add — pnpm workspace explicit packages
+
+Codex P1 finding: при появлении `.gate-trusted/package.json` под workspace
+root, pnpm в будущих версиях мог бы начать сканировать subdirs и принимать
+`.gate-trusted/` за второй workspace-проект. `pnpm-lock.yaml` имеет только
+root importer → `pnpm install --frozen-lockfile` падал бы.
+
+В pnpm 10.33 этого не происходит (`resolved 1` в реальном run), но защищаем
+явным `packages: ["."]` в `pnpm-workspace.yaml` — pnpm обязан использовать
+ровно root и не сканировать subdirs ни в одной версии.
+
 ## Acceptance
 
 - `pnpm run preflight` зелёный локально

--- a/specs/010-fix-pr-ref-gate-scripts/tasks.md
+++ b/specs/010-fix-pr-ref-gate-scripts/tasks.md
@@ -1,0 +1,24 @@
+# Tasks 010: Fix PR-ref gate scripts
+
+## F1 — ai-review.yml: checkout default_branch
+
+- [x] Заменить single checkout на explicit `ref: default_branch`
+- [x] Inline-комментарий с threat model
+
+## F2 — pr-guard.yml: two-checkout pattern
+
+- [x] Trusted checkout в `.gate-trusted/` first
+- [x] PR checkout в workspace root second с `clean: false`
+- [x] `node scripts/check-feature-memory.mjs` → `.gate-trusted/`
+- [x] `pnpm run check:repo` → `node .gate-trusted/scripts/check-static-baseline.mjs`
+
+## F3 — Docs
+
+- [x] `ai-pr-workflow.md` Hard Gates: пункт про trusted-base
+
+## CI / preflight
+
+- [x] `pnpm run preflight` зелёный локально
+- [ ] `guard` зелёный на PR
+- [ ] `baseline-checks` зелёный на PR
+- [ ] `ai-review` зелёный на PR

--- a/specs/010-fix-pr-ref-gate-scripts/tasks.md
+++ b/specs/010-fix-pr-ref-gate-scripts/tasks.md
@@ -7,10 +7,14 @@
 
 ## F2 — pr-guard.yml: two-checkout pattern
 
-- [x] Trusted checkout в `.gate-trusted/` first
-- [x] PR checkout в workspace root second с `clean: false`
+- [x] PR checkout в workspace root first
+- [x] Trusted checkout в `.gate-trusted/` second
 - [x] `node scripts/check-feature-memory.mjs` → `.gate-trusted/`
 - [x] `pnpm run check:repo` → `node .gate-trusted/scripts/check-static-baseline.mjs`
+- [x] Fix #1: первый прогон провалился (run 25027611454) — `actions/checkout`
+      v6 при втором checkout на workspace root делает "Deleting the contents",
+      сносит `.gate-trusted/`. `clean: false` тут не помогает — это другая
+      фаза. Решение: поменять порядок на PR-first.
 
 ## F3 — Docs
 

--- a/specs/010-fix-pr-ref-gate-scripts/tasks.md
+++ b/specs/010-fix-pr-ref-gate-scripts/tasks.md
@@ -15,6 +15,10 @@
       v6 при втором checkout на workspace root делает "Deleting the contents",
       сносит `.gate-trusted/`. `clean: false` тут не помогает — это другая
       фаза. Решение: поменять порядок на PR-first.
+- [x] Fix #2: Codex P1 finding (run 25028103989) — `pnpm-workspace.yaml` без
+      `packages:` мог бы триггерить scanning subdirs в будущих версиях pnpm,
+      и `.gate-trusted/package.json` ломал бы frozen-lockfile install.
+      Решение: явный `packages: ["."]` в `pnpm-workspace.yaml`.
 
 ## F3 — Docs
 


### PR DESCRIPTION
## Summary

- `actions/checkout` в `pr-guard.yml` и `ai-review.yml` тянул workspace по PR-ref, поэтому `node scripts/check-feature-memory.mjs`, `scripts/resolve-pr-context.mjs`, `scripts/ai-review-gate.mjs` и `pnpm run check:repo` исполнялись из untrusted PR-tree. Контрибьютор мог подменить gate-скрипт в PR и пройти required check без реальной проверки.
- `ai-review.yml`: одиночный checkout с явным `ref: ${{ github.event.repository.default_branch }}`. Gate-скрипты читают PR-контекст через `GITHUB_EVENT_PATH` и API, поэтому filesystem PR-а им не нужен.
- `pr-guard.yml`: two-checkout pattern. Trusted main в `.gate-trusted/` (gate-скрипты), PR в workspace root (`clean: false`, чтобы первый чекаут не снёс). `node scripts/check-feature-memory.mjs` и `pnpm run check:repo` заменены на trusted-версии в `.gate-trusted/scripts/`. `pnpm install --frozen-lockfile` остаётся: pnpm-binary доверенный, валидация PR-овского lockfile это и есть цель.
- Параллель с фиксом, который уже приземлился в tone-of-voice. Spec в `specs/010-fix-pr-ref-gate-scripts/`. Hard Gate про trusted-base добавлен в `ai-pr-workflow.md`.

## Test plan

- [x] `pnpm run preflight` зелёный локально
- [x] `node scripts/check-feature-memory.mjs origin/main HEAD --worktree` проходит через `specs/010-fix-pr-ref-gate-scripts/{spec,plan,tasks}.md`
- [ ] `guard` зелёный на этом PR (новый workflow активируется сразу — `pull_request` использует workflow-файл из PR head для same-repo PR)
- [ ] `baseline-checks` зелёный
- [ ] `ai-review` зелёный
- [ ] Vercel preview здоровый (фронтенд не трогаем, должен быть identical к main)

## Out of scope

- Inline shell в `pr-guard.yml` (docs coverage check) tamper-prone через изменение workflow-файла. Защита другого класса: branch protection и code review.
- `pnpm install --frozen-lockfile` без `--ignore-scripts` оставляет supply-chain вектор через postinstall. Отдельный hardening PR.
- `osv-scan.yml` и `ci.yml` сознательно сканируют/билдят PR-tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)