### PR TITLE
docs: use @ syntax for CLAUDE.md doc references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,9 @@
 
 ## Документация
 
-- Конституция процесса: `.specify/memory/constitution.md`
-- Карта docs: `docs_dreamboard/README.md`
-- Идея проекта: `docs_dreamboard/project-idea.md`
+- Конституция процесса: @.specify/memory/constitution.md
+- Карта docs: @docs_dreamboard/README.md
+- Идея проекта: @docs_dreamboard/project-idea.md
 - Frontend: `docs_dreamboard/project/frontend/frontend-docs.md`
 - Orchestration: `docs_dreamboard/project/devops/ai-orchestration-protocol.md`
 - PR loop: `docs_dreamboard/project/devops/ai-pr-workflow.md`

--- a/docs_dreamboard/project/devops/ai-runner.md
+++ b/docs_dreamboard/project/devops/ai-runner.md
@@ -120,7 +120,7 @@ without a complete `specs/<feature-id>/` update.
 For `dreamboard`, product-code paths are:
 
 - `index.html`
-- `package.json` and `package-lock.json`
+- `package.json`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml`
 - `.htmlvalidate.json`
 - `.github/workflows/`
 - `scripts/`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -132,7 +132,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -144,7 +144,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   glob@13.0.6:
     dependencies:

--- a/specs/011-fast-uri-osv-remediation/plan.md
+++ b/specs/011-fast-uri-osv-remediation/plan.md
@@ -1,0 +1,24 @@
+# Plan 011: fast-uri OSV Remediation
+
+## Approach
+
+Use pnpm to refresh only the affected transitive package in the lockfile. The
+direct dependency set remains unchanged, which keeps the patch focused on the
+security finding reported by OSV Scan.
+
+## Changes
+
+1. Run `pnpm update fast-uri --lockfile-only`.
+2. Verify the lockfile now resolves `fast-uri@3.1.2`.
+3. Add feature-memory files for the lockfile remediation so PR Guard can
+   evaluate the product-path change.
+4. Update the devops runner documentation to list `pnpm-lock.yaml` and
+   `pnpm-workspace.yaml` as feature-memory product paths.
+
+## Verification
+
+- `rg -n "fast-uri" pnpm-lock.yaml`
+- `git diff --check`
+- `pnpm install --frozen-lockfile`
+- `pnpm run preflight`
+- GitHub PR checks after push

--- a/specs/011-fast-uri-osv-remediation/spec.md
+++ b/specs/011-fast-uri-osv-remediation/spec.md
@@ -1,0 +1,33 @@
+# Spec 011: fast-uri OSV Remediation
+
+## Problem
+
+The PR branch resolves `fast-uri@3.1.0` through `ajv@8.18.0` in
+`pnpm-lock.yaml`. GitHub OSV Scan reports two High vulnerabilities for that
+transitive package:
+
+- GHSA-q3j6-qgpj-74h6, fixed in `fast-uri@3.1.1`
+- GHSA-v39h-62p7-jpjc, fixed in `fast-uri@3.1.2`
+
+This blocks the PR even though the visible product change is documentation-only.
+
+## Goal
+
+Refresh the pnpm lockfile so the existing dependency graph resolves
+`fast-uri@3.1.2` or newer without changing direct dependencies or app behavior.
+
+## Scope
+
+- Update `pnpm-lock.yaml` for the vulnerable transitive package.
+- Keep `package.json` unchanged.
+- Keep runtime application code unchanged.
+- Record the lockfile remediation in feature memory because `pnpm-lock.yaml` is
+  a product path enforced by PR Guard.
+
+## Acceptance
+
+- `pnpm-lock.yaml` contains no `fast-uri@3.1.0` references.
+- `pnpm run preflight` passes locally after dependencies are installed.
+- GitHub `osv-scan` passes on the PR head.
+- GitHub `guard` passes with the trusted feature-memory gate.
+- Codex AI Review is triggered for the final PR head.

--- a/specs/011-fast-uri-osv-remediation/tasks.md
+++ b/specs/011-fast-uri-osv-remediation/tasks.md
@@ -1,0 +1,20 @@
+# Tasks 011: fast-uri OSV Remediation
+
+## Lockfile
+
+- [x] Update `fast-uri` in `pnpm-lock.yaml` from `3.1.0` to `3.1.2`.
+- [x] Confirm no `fast-uri@3.1.0` references remain.
+- [x] Keep `package.json` unchanged.
+
+## Feature Memory and Docs
+
+- [x] Add `spec.md`, `plan.md`, and `tasks.md` for the remediation.
+- [x] Document that `pnpm-lock.yaml` and `pnpm-workspace.yaml` are product
+      paths in the AI runner feature-memory gate notes.
+
+## Verification
+
+- [x] Run `pnpm install --frozen-lockfile`.
+- [x] Run `pnpm run preflight`.
+- [ ] Confirm GitHub `guard`, `osv-scan`, and `AI Review` pass on the final PR
+      head.


### PR DESCRIPTION
## Summary
- Convert top documentation references in CLAUDE.md to `@` syntax (constitution, docs map, project idea)
- `@path` makes Claude Code auto-load file content at session start

## Why
Per Anthropic recommendation. Plain backtick paths require an explicit Read tool call.

## Scope
Only top 3 most critical paths in the Documentation section. The rest remain as backticks (still findable as an index).

## Test plan
- [ ] baseline-checks + guard + AI Review pass
- [ ] No broken paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)