### PR TITLE
[codex] Fix default locale to English

### DIFF
--- a/docs_dreamboard/project/frontend/frontend-docs.md
+++ b/docs_dreamboard/project/frontend/frontend-docs.md
@@ -7,6 +7,7 @@ The current application is still a static frontend, but it is no longer entirely
 - [index.html](/Users/kristina.kurashova/projects/dreamboard/index.html) for the app shell and semantic markup
 - [app.css](/Users/kristina.kurashova/projects/dreamboard/src/styles/app.css) for the full visual layer
 - [app.js](/Users/kristina.kurashova/projects/dreamboard/src/scripts/app.js) for landing and editor orchestration
+- [locale-boot.js](/Users/kristina.kurashova/projects/dreamboard/src/scripts/locale-boot.js) for early cookie-based locale boot before the main module runs
 - [draft-store.js](/Users/kristina.kurashova/projects/dreamboard/src/scripts/draft-store.js) for browser-side draft persistence
 - [i18n.js](/Users/kristina.kurashova/projects/dreamboard/src/scripts/i18n.js) for locale dictionaries
 - [landing-photo.js](/Users/kristina.kurashova/projects/dreamboard/src/scripts/landing-photo.js) for the embedded landing media asset
@@ -57,6 +58,18 @@ The current static app now treats phone layouts as a separate editor mode:
 - phone landscape switches into a true side-by-side shell so the tools and canvas use the wider viewport instead of reusing the portrait bottom-sheet layout
 - editor return controls are icon-only, with localized tooltips instead of visible labels to keep the shell visually lighter
 
+## Locale Boot
+
+The static shell is English-first. The app does not infer language from
+`navigator.language`; a first-time visitor without a locale cookie sees English
+until they explicitly choose another language.
+
+Explicit language choices are stored in the first-party `dreamboard_locale`
+cookie. A small same-origin boot script reads that cookie before the main module
+runs, sets the document language, and only hides the body briefly when a known
+non-English preference exists so the main module can apply localized copy before
+the page becomes visible. Invalid or missing cookie values fall back to English.
+
 ## Build Contract
 
 The repository keeps a static build layer:
@@ -69,12 +82,13 @@ The repository keeps a static build layer:
 
 The current editor now preserves the working board as a browser draft:
 
-- the draft snapshot stores the current locale plus a Fabric JSON representation of all non-placeholder user objects
+- the draft snapshot stores a Fabric JSON representation of all non-placeholder user objects
 - the primary storage layer is IndexedDB, which is a better fit than `localStorage` for image-heavy boards and structured data
 - `localStorage` remains only as a lightweight fallback when IndexedDB is unavailable
 - save operations are debounced during editing and flushed again on `visibilitychange` / `pagehide`
 - the draft is restored automatically the next time the editor opens in the same browser
 - draft persistence is intentionally silent in the UI; the app keeps autosaving without a visible “draft saved” badge
+- locale preference is intentionally separate from draft persistence and lives in the `dreamboard_locale` cookie
 
 This keeps persistence local-first without introducing backend state or breaking the static deploy model.
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ru">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta
@@ -20,6 +20,8 @@
       sizes="180x180"
       href="./src/assets/apple-touch-icon.png"
     />
+
+    <script src="./src/scripts/locale-boot.js"></script>
 
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=DM+Sans:wght@400;500;700&family=Playfair+Display:wght@400;700&family=Montserrat:wght@400;700&family=Lora:ital,wght@0,400;1,400&family=Oswald:wght@400;700&family=Raleway:wght@400;700&family=Poppins:wght@400;700&family=Merriweather:wght@400;700&family=Pacifico&family=Caveat:wght@400;700&family=Dancing+Script:wght@700&family=Anton&family=Ubuntu:wght@400;700&family=Marck+Script&family=Bad+Script&display=swap"
@@ -43,7 +45,7 @@
         <div class="landing-header-bar">
           <h1>DREAM <span style="color: var(--pantone-yellow)">BOARD</span></h1>
           <div class="lang-switcher">
-            <button type="button" id="langBtn">RU</button>
+            <button type="button" id="langBtn">EN</button>
           </div>
         </div>
       </header>
@@ -57,10 +59,10 @@
               class="hero-title hero-title-center landing-title-unified"
               id="l-hero-title"
             >
-              Создай свою карту желаний бесплатно, без регистрации
+              Create your vision board for free — no registration
             </h2>
             <button type="button" class="cta-btn cta-btn-center" id="l-go-btn">
-              Вперед
+              Go
             </button>
           </div>
         </div>
@@ -72,7 +74,7 @@
           <div class="landing-two-col landing-two-col-what">
             <div class="slide-visual slide-visual-photo" aria-hidden="true">
               <div class="slide-overlay-title" id="l-what-title">
-                Что такое карта желаний?
+                What is a vision board?
               </div>
               <img
                 class="slide-photo"
@@ -83,10 +85,10 @@
 
             <div class="what-text-col">
               <p class="slide-text slide-text-what" id="l-what-text">
-                Карта желаний это мощный инструмент наглядной визуализации ваших
-                желаний по секторам жизни. Вы сами выбираете картинки, которые
-                вам откликаются и это повышает вероятность реализации желаний в
-                разы.
+                A vision board is a powerful tool for visualizing your goals
+                across life areas. You choose images that resonate with you —
+                and that can dramatically increase the odds of making your goals
+                real.
               </p>
             </div>
           </div>
@@ -100,9 +102,44 @@
             class="rules-title rules-title-landing landing-title-unified"
             id="l-rules-title"
           >
-            Правила создания карты желаний
+            Rules for creating a vision board
           </h3>
-          <ul class="rules-list rules-list-landing" id="l-rules-list"></ul>
+          <ul class="rules-list rules-list-landing" id="l-rules-list">
+            <li>
+              Bring a good mood with you — it helps you catch the right vibe
+            </li>
+            <li>
+              Place your current favorite photo in the center — one that feels
+              pleasant and connected to happiness, success, wealth, luxury, or
+              love
+            </li>
+            <li>
+              Write wishes specifically with numbers and facts, in affirmative
+              form as if it already happened (no “not”). For example: my income
+              is $10,000/month, I have 10,000 Instagram followers, etc.
+            </li>
+            <li>
+              Your wishes should be achievable within the time period you're
+              making the board for
+            </li>
+            <li>
+              An optimal horizon is 1–3 years — that's realistically enough time
+              to make many wishes come true
+            </li>
+            <li>
+              Add at least one wish that will come true very soon (a planned
+              trip, a big purchase, etc.). This signals your brain that the
+              mechanism works
+            </li>
+            <li>
+              Near your photo in the center you can add a foundational caption.
+              For example: My 2026
+            </li>
+            <li>
+              You can also add captions to images that aren't obvious. For
+              example: clear skin, C1-level English, etc.
+            </li>
+          </ul>
         </div>
       </section>
 
@@ -114,14 +151,14 @@
               class="hero-title hero-title-final landing-title-unified"
               id="l-final-title"
             >
-              Мечтам пора стать реальностью
+              It's time to make dreams real
             </h2>
             <button
               type="button"
               class="cta-btn cta-btn-center"
               id="l-final-btn"
             >
-              Вперед
+              Go
             </button>
           </div>
         </div>
@@ -166,7 +203,7 @@
             id="langBtnEditorMobile"
             aria-label="Switch language"
           >
-            RU
+            EN
           </button>
         </div>
       </div>
@@ -196,16 +233,16 @@
                   ></path>
                 </svg>
               </button>
-              <button type="button" id="langBtnEditor">RU</button>
+              <button type="button" id="langBtnEditor">EN</button>
             </div>
           </div>
 
           <div class="control-group" style="border-bottom: none">
             <div class="section-title" id="t-images" style="display: none">
-              Изображения
+              Images
             </div>
             <label for="fileInput" class="file-input-label" id="t-upload"
-              >Загрузить изображения</label
+              >Upload Images</label
             >
             <input
               type="file"
@@ -213,8 +250,8 @@
               multiple
               accept="image/png,image/jpeg,image/webp,image/gif"
             />
-            <button type="button" id="t-addtext">Добавить текст</button>
-            <button type="button" id="t-download">Скачать PNG</button>
+            <button type="button" id="t-addtext">Add Text</button>
+            <button type="button" id="t-download">Download PNG</button>
           </div>
         </aside>
 
@@ -366,12 +403,12 @@
     >
       <div class="editor-rotate-card">
         <div class="editor-rotate-header">
-          <h2 id="rotateHintTitle">В горизонтали удобнее</h2>
+          <h2 id="rotateHintTitle">Landscape gives you more room</h2>
           <button
             class="editor-rotate-close"
             type="button"
             id="rotateHintCloseBtn"
-            aria-label="Закрыть подсказку"
+            aria-label="Close the rotation hint"
           >
             <svg
               viewBox="0 0 24 24"
@@ -404,7 +441,7 @@
           </div>
           <div class="editor-rotate-copy">
             <p id="rotateHintText">
-              Редактор уже работает. Разверни телефон для более широкого холста.
+              Rotate your phone to work with the canvas more easily.
             </p>
           </div>
         </div>
@@ -461,13 +498,13 @@
       <div class="donate-modal">
         <div class="donate-modal-header">
           <h2 class="donate-modal-title" id="donateModalTitle">
-            Поддержать проект
+            Support the project
           </h2>
           <button
             class="donate-modal-close"
             type="button"
             id="donateModalCloseBtn"
-            aria-label="Закрыть"
+            aria-label="Close"
           >
             <svg
               viewBox="0 0 24 24"
@@ -484,15 +521,15 @@
         </div>
         <div class="donate-modal-content">
           <p class="donate-modal-text" id="donateModalText">
-            Если этот редактор был полезен — донаты приветствуются.<br /><br />Обратную
-            связь, а также идеи по улучшению вы можете отправить мне в личные
-            сообщения в
+            If this editor was helpful — tips are welcome.<br /><br />Feedback
+            and ideas for improvements: send me a DM on
             <a
               href="https://instagram.com/ks_aquila"
               rel="noopener noreferrer"
               target="_blank"
               >instagram.com/ks_aquila</a
-            >. Спасибо ❤️<br /><br />И пусть все задуманное исполнится ✨
+            >. Thank you ❤️<br /><br />May everything you've envisioned come
+            true ✨
           </p>
 
           <div class="donate-actions">
@@ -524,7 +561,7 @@
                   stroke-linejoin="round"
                 ></path>
               </svg>
-              <span id="donateMatecitoLabel">Задонатить</span>
+              <span id="donateMatecitoLabel">Leave a tip</span>
 
               <!-- Original embed (kept for compatibility) -->
               <img

--- a/package.json
+++ b/package.json
@@ -26,5 +26,10 @@
   "engines": {
     "node": ">=20",
     "pnpm": ">=10.16"
+  },
+  "pnpm": {
+    "overrides": {
+      "brace-expansion": "5.0.6"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion: 5.0.6
+
 importers:
 
   .:
@@ -34,8 +37,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   fast-deep-equal@3.1.3:
@@ -138,7 +141,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -173,7 +176,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 

--- a/specs/010-default-english-cookie-locale/plan.md
+++ b/specs/010-default-english-cookie-locale/plan.md
@@ -1,0 +1,25 @@
+# Plan 010: default English cookie locale
+
+## Slice 1: Static English Fallback
+
+- Change `index.html` visible fallback copy and `html lang` to English.
+- Ensure language buttons show `EN` before JavaScript runs.
+
+## Slice 2: Cookie Locale Boot
+
+- Add a small same-origin boot script that reads a valid locale cookie before
+  body rendering.
+- Hide the body only when a non-English cookie is present, then reveal it after
+  the module applies localized strings.
+
+## Slice 3: Runtime Locale Source
+
+- Initialize `currentLang` from the boot script/cookie or English fallback.
+- Write the locale cookie only after explicit language toggles.
+- Ignore legacy `snapshot.lang` values while still restoring draft canvas data.
+
+## Slice 4: Documentation and Validation
+
+- Update frontend docs with the locale contract.
+- Run repository checks.
+- Smoke-check no-cookie English-first and cookie-backed Russian render locally.

--- a/specs/010-default-english-cookie-locale/spec.md
+++ b/specs/010-default-english-cookie-locale/spec.md
@@ -1,0 +1,37 @@
+# Spec 010: default English cookie locale
+
+## Goal
+
+Make English the no-preference first render for the static app, and persist an
+explicit user language choice in a cookie so repeat visits render in the chosen
+language without a visible Russian-to-English or English-to-other-language text
+swap.
+
+## Scope
+
+- Change the static HTML shell to English-first content and metadata.
+- Stop selecting the initial language from `navigator.language`.
+- Store explicit language changes in a first-party cookie.
+- Use the cookie as the source of truth for known locale preference.
+- Prevent saved editor drafts from silently overriding the chosen UI locale.
+- Document the locale boot behavior in frontend docs.
+
+## Non-Goals
+
+- No backend, account, or server-side locale negotiation.
+- No new framework or routing layer.
+- No changes to the available locale dictionaries.
+- No product copy rewrite beyond aligning existing static fallback copy with
+  the existing English dictionary.
+
+## Acceptance Criteria
+
+1. A first-time visitor with no locale cookie sees English content on first
+   paint, regardless of browser language.
+2. The app does not auto-switch from English based on `navigator.language`.
+3. When the user clicks the language toggle, the selected locale is written to a
+   cookie.
+4. On a repeat visit with a valid locale cookie, the app initializes to that
+   locale.
+5. A saved draft can restore canvas content without changing the UI locale.
+6. `pnpm run ci` passes.

--- a/specs/010-default-english-cookie-locale/tasks.md
+++ b/specs/010-default-english-cookie-locale/tasks.md
@@ -1,0 +1,9 @@
+# Tasks 010: default English cookie locale
+
+- [x] Add feature memory
+- [x] Convert static fallback copy to English
+- [x] Add cookie locale boot script
+- [x] Update app language initialization and persistence
+- [x] Update frontend docs
+- [x] Run `pnpm run ci`
+- [x] Smoke-check locally

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -6,11 +6,12 @@ import {
   writeDraftSnapshotSyncFallback,
 } from "./draft-store.js";
 
-const LANG_KEYS = Object.keys(translations);
-const browserLang = navigator.language.split("-")[0].toUpperCase();
-let currentLang = LANG_KEYS.includes(browserLang)
-  ? browserLang
-  : LANG_KEYS[0] || "RU";
+const DEFAULT_LANG = "EN";
+const LOCALE_COOKIE_NAME = "dreamboard_locale";
+const LOCALE_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+const LANG_KEYS = ["EN", "RU", "ES"].filter((key) => translations[key]);
+const bootLocale = window.__dreamboardLocaleBoot?.initialLocale || DEFAULT_LANG;
+let currentLang = LANG_KEYS.includes(bootLocale) ? bootLocale : DEFAULT_LANG;
 const MOBILE_BREAKPOINT = 900;
 const DRAFT_SCHEMA_VERSION = 1;
 const DRAFT_SAVE_DEBOUNCE_MS = 500;
@@ -79,6 +80,27 @@ let currentSaveStatusKey = "saveIdle";
 let draftBootstrapComplete = false;
 let draftBootstrapPromise = null;
 let rotateHintDismissed = false;
+
+function writeLocaleCookie(lang) {
+  const secureAttribute =
+    window.location.protocol === "https:" ? "; Secure" : "";
+  document.cookie =
+    [
+      `${LOCALE_COOKIE_NAME}=${encodeURIComponent(lang)}`,
+      `Max-Age=${LOCALE_COOKIE_MAX_AGE_SECONDS}`,
+      "Path=/",
+      "SameSite=Lax",
+    ].join("; ") + secureAttribute;
+}
+
+function revealLocaleBoot() {
+  if (window.__dreamboardLocaleBoot?.reveal) {
+    window.__dreamboardLocaleBoot.reveal();
+    return;
+  }
+
+  document.documentElement.removeAttribute("data-locale-pending");
+}
 
 const canvas = new fabric.Canvas("visionBoard", {
   width: 960,
@@ -319,11 +341,13 @@ function applyLanguageUI({ syncPlaceholders = true } = {}) {
   }
   applyToolbarTooltips();
   setSaveStatus(currentSaveStatusKey);
+  revealLocaleBoot();
 }
 
 function toggleLang() {
   const currentIndex = LANG_KEYS.indexOf(currentLang);
   currentLang = LANG_KEYS[(currentIndex + 1) % LANG_KEYS.length];
+  writeLocaleCookie(currentLang);
   applyLanguageUI();
   if (draftBootstrapComplete) {
     scheduleDraftSave();
@@ -382,7 +406,6 @@ function buildDraftSnapshot() {
   return {
     schemaVersion: DRAFT_SCHEMA_VERSION,
     updatedAt: new Date().toISOString(),
-    lang: currentLang,
     canvas: {
       width: canvas.getWidth(),
       height: canvas.getHeight(),
@@ -466,13 +489,8 @@ async function restoreDraftSnapshot(snapshot) {
 }
 
 async function bootstrapDraftState() {
+  applyLanguageUI();
   const snapshot = await readDraftSnapshot();
-
-  if (snapshot?.lang && LANG_KEYS.includes(snapshot.lang)) {
-    currentLang = snapshot.lang;
-  }
-
-  applyLanguageUI({ syncPlaceholders: !snapshot });
   if (snapshot) {
     await restoreDraftSnapshot(snapshot);
     setSaveStatus("saveSaved");

--- a/src/scripts/locale-boot.js
+++ b/src/scripts/locale-boot.js
@@ -1,0 +1,47 @@
+(function () {
+  const COOKIE_NAME = "dreamboard_locale";
+  const DEFAULT_LOCALE = "EN";
+  const SUPPORTED_LOCALES = new Set(["EN", "RU", "ES"]);
+
+  function readLocaleCookie() {
+    const cookie = document.cookie
+      .split(";")
+      .map((part) => part.trim())
+      .find((part) => part.startsWith(`${COOKIE_NAME}=`));
+
+    if (!cookie) {
+      return "";
+    }
+
+    const rawValue = cookie.slice(COOKIE_NAME.length + 1);
+
+    try {
+      const normalized = decodeURIComponent(rawValue).toUpperCase();
+      return SUPPORTED_LOCALES.has(normalized) ? normalized : "";
+    } catch {
+      return "";
+    }
+  }
+
+  const locale = readLocaleCookie();
+  const initialLocale = locale || DEFAULT_LOCALE;
+
+  document.documentElement.lang = initialLocale.toLowerCase();
+
+  if (locale && locale !== DEFAULT_LOCALE) {
+    document.documentElement.setAttribute("data-locale-pending", "true");
+  }
+
+  const revealFallbackTimer = window.setTimeout(() => {
+    document.documentElement.removeAttribute("data-locale-pending");
+  }, 1500);
+
+  window.__dreamboardLocaleBoot = {
+    locale,
+    initialLocale,
+    reveal() {
+      window.clearTimeout(revealFallbackTimer);
+      document.documentElement.removeAttribute("data-locale-pending");
+    },
+  };
+})();

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -28,6 +28,10 @@ html {
   overflow: hidden;
 }
 
+html[data-locale-pending="true"] body {
+  visibility: hidden;
+}
+
 /* =========
            LANDING
            ========= */


### PR DESCRIPTION
## What changed

- Default first render is now English when no user language cookie exists.
- Added an early locale boot script that reads `dreamboard_locale` before app hydration and prevents visible RU/ES flicker for known returning users.
- Persisted explicit language choices in a cookie and removed language from draft-board snapshots.
- Documented the locale boot flow and added feature-memory notes for the change.
- Pinned transitive `brace-expansion` to `5.0.6` so the OSV scan no longer blocks the PR.

## Why

Users reported a visible language jump during page load because the app guessed locale from browser language after English static HTML had already rendered. The new behavior is English-first until the user explicitly chooses another language, then future visits render directly in that chosen language.

## Validation

- `pnpm run preflight`
- Browser smoke test for no-cookie English load, explicit RU selection, RU cookie reload, and empty console errors.

Co-authored-by: Codex <codex@openai.com>