### PR TITLE
fix: preserve editor route on reload

### DIFF
--- a/docs_dreamboard/project/frontend/frontend-docs.md
+++ b/docs_dreamboard/project/frontend/frontend-docs.md
@@ -99,6 +99,9 @@ The static app now treats `#editor` as the editor route:
   does not flash during refresh
 - refreshing a browser tab while `#editor` is present opens the editor shell
   immediately and then restores the local draft
+- editing controls and canvas interactions stay locked until draft restore
+  completes, so slow image-heavy drafts cannot overwrite new edits made during
+  bootstrap
 - browser back and forward navigation keep the visible view synchronized with
   the hash route
 - using the editor home/back controls clears `#editor`, so a later reload stays

--- a/docs_dreamboard/project/frontend/frontend-docs.md
+++ b/docs_dreamboard/project/frontend/frontend-docs.md
@@ -90,6 +90,22 @@ The current editor now preserves the working board as a browser draft:
 - draft persistence is intentionally silent in the UI; the app keeps autosaving without a visible “draft saved” badge
 - locale preference is intentionally separate from draft persistence and lives in the `dreamboard_locale` cookie
 
+## Editor Reload Route
+
+The static app now treats `#editor` as the editor route:
+
+- entering the editor from landing controls pushes `#editor` into the URL
+- the head boot script marks `#editor` before CSS loads, so the landing view
+  does not flash during refresh
+- refreshing a browser tab while `#editor` is present opens the editor shell
+  immediately and then restores the local draft
+- browser back and forward navigation keep the visible view synchronized with
+  the hash route
+- using the editor home/back controls clears `#editor`, so a later reload stays
+  on the landing view
+- canvas contents still come from local draft persistence; the route stores only
+  the active view, not board data
+
 This keeps persistence local-first without introducing backend state or breaking the static deploy model.
 
 ## Planned Refactor Direction

--- a/specs/012-editor-reload-state/plan.md
+++ b/specs/012-editor-reload-state/plan.md
@@ -11,8 +11,10 @@
 - On initial load, open the editor automatically when the hash route is present.
 - Mark the initial editor route before CSS loads so the landing view cannot
   paint first.
+- Lock canvas-mutating editor controls until draft restore has completed.
 - Listen for hash changes so browser back/forward stays in sync with the view.
-- Keep draft bootstrap sequencing intact before showing the editor.
+- Keep draft bootstrap sequencing intact while showing the editor shell
+  immediately.
 
 ## Slice 3: Documentation and Validation
 

--- a/specs/012-editor-reload-state/plan.md
+++ b/specs/012-editor-reload-state/plan.md
@@ -1,0 +1,21 @@
+# Plan 012: editor reload state
+
+## Slice 1: Static Editor Route
+
+- Add a lightweight hash route for the editor view.
+- Push the editor hash when entering the editor from landing CTAs.
+- Clear the hash when using editor back/home controls.
+
+## Slice 2: Reload and History Restore
+
+- On initial load, open the editor automatically when the hash route is present.
+- Mark the initial editor route before CSS loads so the landing view cannot
+  paint first.
+- Listen for hash changes so browser back/forward stays in sync with the view.
+- Keep draft bootstrap sequencing intact before showing the editor.
+
+## Slice 3: Documentation and Validation
+
+- Update frontend docs with the route-backed editor reload contract.
+- Run repository checks.
+- Smoke-check editor refresh with a local draft.

--- a/specs/012-editor-reload-state/spec.md
+++ b/specs/012-editor-reload-state/spec.md
@@ -13,6 +13,8 @@ draft in the same browser session.
   view.
 - Continue relying on local draft persistence for canvas objects and uploaded
   images.
+- Keep editor interactions locked while the local draft restore is still
+  pending.
 - Document the editor route and draft restore contract.
 
 ## Non-Goals
@@ -30,7 +32,8 @@ draft in the same browser session.
 3. Refreshing while on the editor route does not flash the landing view before
    the editor appears.
 4. A saved local draft restores uploaded images and text objects after refresh.
-5. Returning to the landing view clears the editor route so future reloads stay
+5. Editor controls cannot mutate the canvas before draft restore completes.
+6. Returning to the landing view clears the editor route so future reloads stay
    on the landing view.
-6. Browser back/forward navigation switches between landing and editor routes.
-7. `pnpm run ci` passes.
+7. Browser back/forward navigation switches between landing and editor routes.
+8. `pnpm run ci` passes.

--- a/specs/012-editor-reload-state/spec.md
+++ b/specs/012-editor-reload-state/spec.md
@@ -1,0 +1,36 @@
+# Spec 012: editor reload state
+
+## Goal
+
+Keep users in the editor after a browser refresh and restore the local board
+draft in the same browser session.
+
+## Scope
+
+- Encode the active editor view in the static app URL.
+- Open the editor automatically when the page loads with the editor route.
+- Clear the editor route when the user intentionally returns to the landing
+  view.
+- Continue relying on local draft persistence for canvas objects and uploaded
+  images.
+- Document the editor route and draft restore contract.
+
+## Non-Goals
+
+- No backend draft storage or account state.
+- No framework/router migration.
+- No new visible draft status UI.
+- No export/download behavior changes.
+
+## Acceptance Criteria
+
+1. Opening the editor updates the URL to an editor route.
+2. Refreshing while on the editor route returns to the editor instead of the
+   landing view.
+3. Refreshing while on the editor route does not flash the landing view before
+   the editor appears.
+4. A saved local draft restores uploaded images and text objects after refresh.
+5. Returning to the landing view clears the editor route so future reloads stay
+   on the landing view.
+6. Browser back/forward navigation switches between landing and editor routes.
+7. `pnpm run ci` passes.

--- a/specs/012-editor-reload-state/tasks.md
+++ b/specs/012-editor-reload-state/tasks.md
@@ -4,6 +4,7 @@
 - [x] Add editor hash route handling
 - [x] Keep reload and browser history in sync
 - [x] Prevent landing first-paint flash on editor reload
+- [x] Lock canvas edits until draft restore completes
 - [x] Update frontend docs
 - [x] Run `pnpm run ci`
 - [x] Smoke-check locally

--- a/specs/012-editor-reload-state/tasks.md
+++ b/specs/012-editor-reload-state/tasks.md
@@ -1,0 +1,9 @@
+# Tasks 012: editor reload state
+
+- [x] Add feature memory
+- [x] Add editor hash route handling
+- [x] Keep reload and browser history in sync
+- [x] Prevent landing first-paint flash on editor reload
+- [x] Update frontend docs
+- [x] Run `pnpm run ci`
+- [x] Smoke-check locally

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -15,6 +15,7 @@ let currentLang = LANG_KEYS.includes(bootLocale) ? bootLocale : DEFAULT_LANG;
 const MOBILE_BREAKPOINT = 900;
 const DRAFT_SCHEMA_VERSION = 1;
 const DRAFT_SAVE_DEBOUNCE_MS = 500;
+const EDITOR_ROUTE_HASH = "#editor";
 
 const landingView = document.getElementById("landingView");
 const editorView = document.getElementById("editorView");
@@ -402,6 +403,24 @@ function syncBodyOverflow() {
       : "";
 }
 
+function isEditorRouteActive() {
+  return window.location.hash === EDITOR_ROUTE_HASH;
+}
+
+function pushEditorRoute() {
+  if (isEditorRouteActive()) return;
+
+  window.history.pushState(null, "", EDITOR_ROUTE_HASH);
+}
+
+function clearEditorRoute() {
+  if (!isEditorRouteActive()) return;
+
+  const url = new URL(window.location.href);
+  url.hash = "";
+  window.history.replaceState(null, "", `${url.pathname}${url.search}`);
+}
+
 function buildDraftSnapshot() {
   return {
     schemaVersion: DRAFT_SCHEMA_VERSION,
@@ -509,10 +528,11 @@ function persistDraftOnExit() {
   void persistDraftSnapshot(snapshot);
 }
 
-async function goToEditor() {
-  if (draftBootstrapPromise) {
-    await draftBootstrapPromise;
-  }
+function clearInitialViewMarker() {
+  document.documentElement.removeAttribute("data-initial-view");
+}
+
+function showEditorShell() {
   landingView.style.display = "none";
   editorView.style.display = "block";
   document.body.classList.add("is-editor-active");
@@ -520,9 +540,27 @@ async function goToEditor() {
   syncBodyOverflow();
   closeSidebar();
   syncEditorViewport();
+  clearInitialViewMarker();
 }
 
-function goToLanding() {
+async function goToEditor({ updateRoute = true } = {}) {
+  if (updateRoute) {
+    pushEditorRoute();
+  }
+
+  showEditorShell();
+
+  if (draftBootstrapPromise) {
+    await draftBootstrapPromise;
+    syncEditorViewport();
+  }
+}
+
+function goToLanding({ updateRoute = true } = {}) {
+  if (updateRoute) {
+    clearEditorRoute();
+  }
+
   landingView.style.display = "block";
   editorView.style.display = "none";
   document.body.classList.remove("is-editor-active");
@@ -533,10 +571,22 @@ function goToLanding() {
   hideFontPopup();
   syncBodyOverflow();
   syncRotateHintVisibility();
+  clearInitialViewMarker();
   requestAnimationFrame(() => {
     updateLandingViewportVars();
     landingView.scrollTo({ top: 0, behavior: "smooth" });
   });
+}
+
+function syncViewWithRoute() {
+  if (isEditorRouteActive()) {
+    void goToEditor({ updateRoute: false });
+    return;
+  }
+
+  if (document.body.classList.contains("is-editor-active")) {
+    goToLanding({ updateRoute: false });
+  }
 }
 
 function hideColorPopup() {
@@ -1558,6 +1608,9 @@ window.visualViewport?.addEventListener("resize", () => {
   syncEditorViewport({ dismissForLandscape: true });
 });
 
+window.addEventListener("hashchange", syncViewWithRoute);
+window.addEventListener("popstate", syncViewWithRoute);
+
 document.addEventListener("visibilitychange", () => {
   if (document.visibilityState === "hidden") {
     persistDraftOnExit();
@@ -1572,4 +1625,8 @@ window.addEventListener("pagehide", () => {
 updateLandingViewportVars();
 syncRotateHintVisibility();
 setLandingPhotos();
+if (isEditorRouteActive()) {
+  showEditorShell();
+}
 draftBootstrapPromise = bootstrapDraftState();
+syncViewWithRoute();

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -80,6 +80,7 @@ let suppressDraftPersistence = false;
 let currentSaveStatusKey = "saveIdle";
 let draftBootstrapComplete = false;
 let draftBootstrapPromise = null;
+let editorInteractionLocked = false;
 let rotateHintDismissed = false;
 
 function writeLocaleCookie(lang) {
@@ -403,6 +404,38 @@ function syncBodyOverflow() {
       : "";
 }
 
+function isEditorActionBlocked() {
+  return editorInteractionLocked || !draftBootstrapComplete;
+}
+
+function setEditorInteractionLocked(locked) {
+  editorInteractionLocked = locked;
+  document.body.classList.toggle("is-editor-restoring", locked);
+  editorView.setAttribute("aria-busy", locked ? "true" : "false");
+  canvas.selection = !locked;
+  canvas.skipTargetFind = locked;
+
+  canvas.getObjects().forEach((object) => {
+    if (object.isPlaceholder) {
+      object.selectable = false;
+      object.evented = false;
+      return;
+    }
+
+    object.selectable = !locked;
+    object.evented = !locked;
+  });
+
+  if (locked) {
+    canvas.discardActiveObject();
+    hideObjectMenu();
+    hideColorPopup();
+    hideFontPopup();
+  }
+
+  canvas.renderAll();
+}
+
 function isEditorRouteActive() {
   return window.location.hash === EDITOR_ROUTE_HASH;
 }
@@ -518,6 +551,7 @@ async function bootstrapDraftState() {
   }
 
   draftBootstrapComplete = true;
+  setEditorInteractionLocked(false);
 }
 
 function persistDraftOnExit() {
@@ -536,6 +570,7 @@ function showEditorShell() {
   landingView.style.display = "none";
   editorView.style.display = "block";
   document.body.classList.add("is-editor-active");
+  setEditorInteractionLocked(!draftBootstrapComplete);
   rotateHintDismissed = false;
   syncBodyOverflow();
   closeSidebar();
@@ -552,7 +587,10 @@ async function goToEditor({ updateRoute = true } = {}) {
 
   if (draftBootstrapPromise) {
     await draftBootstrapPromise;
-    syncEditorViewport();
+    if (document.body.classList.contains("is-editor-active")) {
+      setEditorInteractionLocked(false);
+      syncEditorViewport();
+    }
   }
 }
 
@@ -561,6 +599,7 @@ function goToLanding({ updateRoute = true } = {}) {
     clearEditorRoute();
   }
 
+  setEditorInteractionLocked(false);
   landingView.style.display = "block";
   editorView.style.display = "none";
   document.body.classList.remove("is-editor-active");
@@ -797,6 +836,8 @@ function syncTextToolStates(obj) {
 }
 
 function toggleBold() {
+  if (isEditorActionBlocked()) return;
+
   const obj = canvas.getActiveObject();
   if (!obj || !(obj.type === "i-text" || obj.type === "text")) return;
   const next = obj.fontWeight === "bold" ? "normal" : "bold";
@@ -808,6 +849,8 @@ function toggleBold() {
 }
 
 function toggleItalic() {
+  if (isEditorActionBlocked()) return;
+
   const obj = canvas.getActiveObject();
   if (!obj || !(obj.type === "i-text" || obj.type === "text")) return;
   const next = obj.fontStyle === "italic" ? "normal" : "italic";
@@ -819,6 +862,8 @@ function toggleItalic() {
 }
 
 function toggleUnderline() {
+  if (isEditorActionBlocked()) return;
+
   const obj = canvas.getActiveObject();
   if (!obj || !(obj.type === "i-text" || obj.type === "text")) return;
   obj.set("underline", !obj.underline);
@@ -829,6 +874,8 @@ function toggleUnderline() {
 }
 
 function duplicateSelectedText() {
+  if (isEditorActionBlocked()) return;
+
   const obj = canvas.getActiveObject();
   if (!obj || !(obj.type === "i-text" || obj.type === "text")) return;
 
@@ -1027,6 +1074,11 @@ function layoutBatchImages(images) {
 }
 
 fileInput?.addEventListener("change", (e) => {
+  if (isEditorActionBlocked()) {
+    e.target.value = "";
+    return;
+  }
+
   const files = e.target.files;
   const ALLOWED_MIME = new Set([
     "image/png",
@@ -1065,6 +1117,8 @@ fileInput?.addEventListener("change", (e) => {
 });
 
 function addText() {
+  if (isEditorActionBlocked()) return;
+
   const text = new fabric.IText(translations[currentLang].defaultText, {
     left: canvas.width / 2,
     top: canvas.height / 2,
@@ -1092,6 +1146,8 @@ function addText() {
 }
 
 function changeZIndex(direction) {
+  if (isEditorActionBlocked()) return;
+
   const obj = canvas.getActiveObject();
   if (!obj) return;
 
@@ -1110,6 +1166,8 @@ function changeZIndex(direction) {
 }
 
 function deleteSelected() {
+  if (isEditorActionBlocked()) return;
+
   const activeObjects = canvas.getActiveObjects();
   canvas.discardActiveObject();
   canvas.remove(...activeObjects);
@@ -1121,6 +1179,8 @@ function deleteSelected() {
 }
 
 function exportBoard() {
+  if (isEditorActionBlocked()) return;
+
   placeholders.forEach((p) => p.set("visible", false));
   canvas.discardActiveObject();
   hideObjectMenu();
@@ -1290,6 +1350,8 @@ function positionObjectMenu() {
 }
 
 omTextColor.addEventListener("input", () => {
+  if (isEditorActionBlocked()) return;
+
   const obj = canvas.getActiveObject();
   if (!obj || !(obj.type === "i-text" || obj.type === "text")) return;
   obj.set("fill", omTextColor.value);
@@ -1299,10 +1361,20 @@ omTextColor.addEventListener("input", () => {
 });
 
 canvas.on("selection:created", () => {
+  if (editorInteractionLocked) {
+    hideObjectMenu();
+    return;
+  }
+
   menuUserPositioned = false;
   positionObjectMenu();
 });
 canvas.on("selection:updated", () => {
+  if (editorInteractionLocked) {
+    hideObjectMenu();
+    return;
+  }
+
   menuUserPositioned = false;
   positionObjectMenu();
 });
@@ -1362,6 +1434,8 @@ canvas.on("text:changed", () => {
   }
 
   function onStart(e) {
+    if (isEditorActionBlocked()) return;
+
     if (e.touches && e.touches.length === 2) {
       const active = canvas.getActiveObject();
       const targetObject = active && !active.isPlaceholder ? active : null;
@@ -1492,6 +1566,7 @@ canvas.on("mouse:down", () => {
 
 window.addEventListener("keydown", (e) => {
   if (editorView.style.display !== "block") return;
+  if (isEditorActionBlocked()) return;
 
   const active = canvas.getActiveObject();
   const editingText = active && active.type === "i-text" && active.isEditing;

--- a/src/scripts/locale-boot.js
+++ b/src/scripts/locale-boot.js
@@ -2,6 +2,7 @@
   const COOKIE_NAME = "dreamboard_locale";
   const DEFAULT_LOCALE = "EN";
   const SUPPORTED_LOCALES = new Set(["EN", "RU", "ES"]);
+  const EDITOR_ROUTE_HASH = "#editor";
 
   function readLocaleCookie() {
     const cookie = document.cookie
@@ -25,8 +26,14 @@
 
   const locale = readLocaleCookie();
   const initialLocale = locale || DEFAULT_LOCALE;
+  const initialView =
+    window.location.hash === EDITOR_ROUTE_HASH ? "editor" : "landing";
 
   document.documentElement.lang = initialLocale.toLowerCase();
+
+  if (initialView === "editor") {
+    document.documentElement.setAttribute("data-initial-view", "editor");
+  }
 
   if (locale && locale !== DEFAULT_LOCALE) {
     document.documentElement.setAttribute("data-locale-pending", "true");
@@ -39,6 +46,7 @@
   window.__dreamboardLocaleBoot = {
     locale,
     initialLocale,
+    initialView,
     reveal() {
       window.clearTimeout(revealFallbackTimer);
       document.documentElement.removeAttribute("data-locale-pending");

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -32,6 +32,18 @@ html[data-locale-pending="true"] body {
   visibility: hidden;
 }
 
+html[data-initial-view="editor"] .landing-view {
+  display: none;
+}
+
+html[data-initial-view="editor"] .editor-view {
+  display: block;
+}
+
+html[data-initial-view="editor"] .sticky-footer {
+  display: none;
+}
+
 /* =========
            LANDING
            ========= */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -773,6 +773,12 @@ button:hover {
   box-sizing: border-box;
 }
 
+body.is-editor-restoring .canvas-area,
+body.is-editor-restoring .control-group,
+body.is-editor-restoring .object-menu {
+  pointer-events: none;
+}
+
 .canvas-wrapper {
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
   background: white;


### PR DESCRIPTION
## Summary

- Keep reloads on `#editor` in the editor instead of briefly showing the landing view.
- Mark the initial editor route before CSS paints, then restore the local draft after the editor shell is visible.
- Add feature memory and document the editor reload route contract.

## Validation

- `pnpm run preflight`
- Browser smoke: delayed `app.js` first-paint check, normal `#editor` reload with restored text, editor home route clear

Co-authored-by: Codex <codex@openai.com>