### PR TITLE
fix: allow dependency-only updates through product guards

### DIFF
--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -78,6 +78,11 @@ jobs:
           echo "Changed files:"
           echo "$changed"
 
+          if node .gate-trusted/scripts/check-feature-memory.mjs --dependency-only "$BASE_REF" "$HEAD_REF"; then
+            echo "Dependency-manifest-only change — durable docs are not required."
+            exit 0
+          fi
+
           tracked_change=false
           while IFS= read -r f; do
             case "$f" in

--- a/docs_dreamboard/project/devops/ai-pr-workflow.md
+++ b/docs_dreamboard/project/devops/ai-pr-workflow.md
@@ -34,6 +34,11 @@ This is the canonical PR loop for `dreamboard`.
 
 - Product changes in `index.html`, `src/`, future app code, or runtime config do
   not start without an active `specs/<feature-id>/` folder.
+- Dependency-only updates are exempt from product documentation and feature
+  memory, while still running the full repository baseline. The guard verifies
+  that `package.json` changes are limited to dependency fields, and it accepts
+  GitHub Actions updates only when a pinned `uses:` revision changes while its
+  action coordinate, including any action subpath, remains unchanged.
 - Local product edits in the main checkout do not count as completed work.
 - If the selected implementation agent path is unavailable, stop and report the
   blocker instead of bypassing the loop.

--- a/scripts/check-feature-memory.mjs
+++ b/scripts/check-feature-memory.mjs
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const args = process.argv.slice(2);
 const inspectWorktree = args.includes("--worktree");
-const filteredArgs = args.filter((arg) => arg !== "--worktree");
+const inspectDependencyOnly = args.includes("--dependency-only");
+const filteredArgs = args.filter(
+  (arg) => arg !== "--worktree" && arg !== "--dependency-only",
+);
 const repoRoot = resolve(process.cwd());
 
 const git = (args) =>
@@ -52,12 +55,139 @@ const changedFiles = git(diffArgs)
   .map((file) => file.trim())
   .filter(Boolean);
 
+const isDependencyManifest = (file) =>
+  file === "package.json" || file === "pnpm-lock.yaml";
+
+const dependencyFields = new Set([
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+]);
+
+const readManifest = (ref, fromWorktree = false) => {
+  try {
+    if (fromWorktree) {
+      return JSON.parse(
+        readFileSync(resolve(repoRoot, "package.json"), "utf8"),
+      );
+    }
+
+    return JSON.parse(git(["show", `${ref}:package.json`]));
+  } catch {
+    return null;
+  }
+};
+
+const withoutDependencyFields = (manifest) => {
+  if (!manifest) {
+    return null;
+  }
+
+  return Object.fromEntries(
+    Object.entries(manifest).filter(([field]) => !dependencyFields.has(field)),
+  );
+};
+
+const usesPinChangeOnly = () => {
+  const workflowFiles = changedFiles.filter((file) =>
+    file.startsWith(".github/workflows/"),
+  );
+
+  if (workflowFiles.length === 0) {
+    return true;
+  }
+
+  const changedLines = git(
+    inspectWorktree
+      ? ["diff", "--unified=0", "HEAD", "--", ...workflowFiles]
+      : [
+          "diff",
+          "--unified=0",
+          `${baseRef}...${headRef}`,
+          "--",
+          ...workflowFiles,
+        ],
+  )
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("+") || line.startsWith("-"))
+    .filter((line) => !line.startsWith("+++") && !line.startsWith("---"));
+
+  const pinnedUse =
+    /^[+-]\s*uses:\s*([\w.-]+(?:\/[\w.-]+)+)@([a-f0-9]{40})(?:\s+#.*)?$/i;
+
+  if (changedLines.length === 0 || changedLines.length % 2 !== 0) {
+    return false;
+  }
+
+  for (let index = 0; index < changedLines.length; index += 2) {
+    const previous = changedLines[index];
+    const next = changedLines[index + 1];
+    const previousMatch = previous.match(pinnedUse);
+    const nextMatch = next.match(pinnedUse);
+
+    if (
+      !previousMatch ||
+      !nextMatch ||
+      !previous.startsWith("-") ||
+      !next.startsWith("+") ||
+      previousMatch[1] !== nextMatch[1]
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const isDependencyOnlyChange = () => {
+  if (changedFiles.length === 0) {
+    return false;
+  }
+
+  if (
+    !changedFiles.every(
+      (file) =>
+        isDependencyManifest(file) || file.startsWith(".github/workflows/"),
+    )
+  ) {
+    return false;
+  }
+
+  if (changedFiles.includes("package.json")) {
+    const comparisonBase = inspectWorktree
+      ? headRef
+      : git(["merge-base", baseRef, headRef]);
+    const baseManifest = readManifest(comparisonBase);
+    const headManifest = readManifest(headRef, inspectWorktree);
+
+    if (
+      !baseManifest ||
+      !headManifest ||
+      JSON.stringify(withoutDependencyFields(baseManifest)) !==
+        JSON.stringify(withoutDependencyFields(headManifest))
+    ) {
+      return false;
+    }
+  }
+
+  return usesPinChangeOnly();
+};
+
+if (inspectDependencyOnly) {
+  process.exit(isDependencyOnlyChange() ? 0 : 1);
+}
+
+if (isDependencyOnlyChange()) {
+  console.log("Dependency-only change; feature memory is not required.");
+  process.exit(0);
+}
+
 // Build-contract and repository-owned orchestration changes should participate
 // in the same feature-memory rule as UI code.
 const isProductPath = (file) =>
   file === "index.html" ||
-  file === "package.json" ||
-  file === "pnpm-lock.yaml" ||
+  isDependencyManifest(file) ||
   file === "pnpm-workspace.yaml" ||
   file === "vercel.json" ||
   file === ".htmlvalidate.json" ||

--- a/specs/015-dependency-only-pr-guards/plan.md
+++ b/specs/015-dependency-only-pr-guards/plan.md
@@ -1,0 +1,6 @@
+# Plan
+
+1. Detect dependency-only diffs by content, not filename alone.
+2. Apply the same narrow exemption in the PR documentation and feature-memory
+   checks.
+3. Document the exception and validate the repository baseline.

--- a/specs/015-dependency-only-pr-guards/spec.md
+++ b/specs/015-dependency-only-pr-guards/spec.md
@@ -1,0 +1,22 @@
+# Dependency-only PR guards
+
+## Goal
+
+Allow automated dependency updates to satisfy the PR guard without pretending
+they are product features, while retaining baseline validation.
+
+## Scope
+
+- Treat a change limited to dependency fields in `package.json`,
+  `pnpm-lock.yaml`, and pinned GitHub Actions `uses:` revisions (including
+  action subpaths with unchanged action coordinates) as a
+  dependency-only update.
+- Exempt only those changes from durable-documentation and feature-memory
+  checks.
+- Preserve baseline installation and repository validation for all PRs.
+
+## Non-goals
+
+- Exempting source, workflow, runtime, or deployment changes.
+- Exempting npm scripts, Node/toolchain settings, or other manifest metadata.
+- Weakening package validation or lockfile enforcement.

--- a/specs/015-dependency-only-pr-guards/tasks.md
+++ b/specs/015-dependency-only-pr-guards/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] Define the narrow dependency-only exemption.
+- [x] Update documentation and feature-memory guard behavior.
+- [x] Validate locally; PR gates are pending publication.


### PR DESCRIPTION
## Summary
- exempt manifest-only dependency updates from documentation and feature-memory requirements
- retain the full baseline validation for every PR

## Validation
- pnpm run ci
- node scripts/check-feature-memory.mjs 09c4ff729bd783af7f5d816a733fe9f35a392f7d 4c02afb2028291468540fe755d0a7a463dbcc0f4

Co-authored-by: Codex <codex@openai.com>