### PR TITLE
fix: require a supported Node runtime

### DIFF
--- a/docs_dreamboard/project/devops/macos-local-runners.md
+++ b/docs_dreamboard/project/devops/macos-local-runners.md
@@ -26,7 +26,7 @@ macOS helpers for:
 
 ## Prerequisites
 
-- macOS with `git`, `gh`, and Node.js 24 available
+- macOS with `git`, `gh`, and Node.js 24.8 or newer available
 - authenticated GitHub CLI for repository variable updates and PR creation
 - Claude Code available locally as the primary implementation agent
 - Codex app or Codex CLI available locally only when you want to hand off the

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "packageManager": "pnpm@10.33.0",
   "engines": {
-    "node": ">=20",
+    "node": ">=24.8.0",
     "pnpm": ">=10.16"
   },
   "pnpm": {

--- a/specs/016-node24-engine-policy/plan.md
+++ b/specs/016-node24-engine-policy/plan.md
@@ -1,0 +1,6 @@
+# Plan
+
+1. Raise the declared Node engine to the minimum supported by the updated
+   validation dependency.
+2. Align the macOS runner documentation.
+3. Validate the static build and repository baseline.

--- a/specs/016-node24-engine-policy/spec.md
+++ b/specs/016-node24-engine-policy/spec.md
@@ -1,0 +1,16 @@
+# Node 24 engine policy
+
+## Goal
+
+Align the declared Node.js engine with the runtime required by the current
+validation toolchain.
+
+## Scope
+
+- Require Node.js 24.8 or newer in `package.json`.
+- Keep the documented local runner prerequisite aligned with the engine.
+
+## Non-goals
+
+- Changing CI's selected Node major version.
+- Updating dependency versions beyond the separate Dependabot PR.

--- a/specs/016-node24-engine-policy/tasks.md
+++ b/specs/016-node24-engine-policy/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] Update the Node engine declaration.
+- [x] Update the local runner prerequisite.
+- [x] Validate locally; pull-request gates are pending publication.


### PR DESCRIPTION
## Summary
- require Node.js 24.8 or newer, matching the validation toolchain
- align local runner documentation

## Validation
- pnpm run ci

Co-authored-by: Codex <codex@openai.com>