### PR TITLE
fix: document checkout v7 workflow contract

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -59,7 +59,7 @@ jobs:
       # Without this a contributor could patch scripts/ in their PR to bypass
       # the required AI Review check.
       - name: Checkout trusted base (default branch)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Bootstrap checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
 
@@ -96,14 +96,14 @@ jobs:
 
       - name: Checkout PR head
         if: steps.pr.outputs.is_pull_request == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: ${{ steps.pr.outputs.checkout_ref }}
 
       - name: Checkout default branch
         if: steps.pr.outputs.is_pull_request != 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Bootstrap checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
 
@@ -97,7 +97,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: ${{ steps.pr.outputs.checkout_ref }}

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Run OSV Scanner
         uses: google/osv-scanner-action/osv-scanner-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -34,19 +34,19 @@ jobs:
     steps:
       # Two-checkout pattern: PR content lives in workspace root for diff and
       # filesystem checks; trusted gate scripts come from main into a sub-path.
-      # Order matters: actions/checkout v6 wipes workspace root if it sees a
+      # Order matters: actions/checkout v7 wipes workspace root if it sees a
       # non-empty directory without a matching .git, so PR must check out
       # first while workspace is empty. The trusted sub-path checkout always
       # ends with main's content even if the PR seeds an adversarial
       # .gate-trusted/, because actions/checkout reinitializes the path.
       - name: Checkout PR content
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
 
       - name: Checkout trusted gate scripts (default branch)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.repository.default_branch }}
           path: .gate-trusted

--- a/docs_dreamboard/project/devops/ai-pr-workflow.md
+++ b/docs_dreamboard/project/devops/ai-pr-workflow.md
@@ -46,7 +46,7 @@ This is the canonical PR loop for `dreamboard`.
 - Gate scripts (`scripts/check-feature-memory.mjs`,
   `scripts/check-static-baseline.mjs`, `scripts/resolve-pr-context.mjs`,
   `scripts/ai-review-gate.mjs`) execute only from `default_branch` via
-  `actions/checkout` with explicit `ref:`. PR Guard uses a two-checkout pattern
+  pinned `actions/checkout` v7 with explicit `ref:`. PR Guard uses a two-checkout pattern
   (`.gate-trusted/` for trusted scripts, workspace root for PR content), so a
   PR cannot tamper with gate logic to bypass required checks.
 

--- a/specs/017-checkout-v7-workflow-contract/plan.md
+++ b/specs/017-checkout-v7-workflow-contract/plan.md
@@ -1,0 +1,5 @@
+# Plan
+
+1. Replace the pinned checkout SHA and v6 annotations in every workflow.
+2. Preserve the PR Guard two-checkout sequence and document its v7 contract.
+3. Run the repository validation commands before publishing the pull request.

--- a/specs/017-checkout-v7-workflow-contract/spec.md
+++ b/specs/017-checkout-v7-workflow-contract/spec.md
@@ -1,0 +1,18 @@
+# Checkout v7 workflow contract
+
+## Goal
+
+Record and consistently apply the `actions/checkout` v7 pin across GitHub
+workflows while preserving the trusted-checkout security boundary.
+
+## Scope
+
+- Upgrade every repository-owned `actions/checkout` pin to v7.0.1.
+- Correct all adjacent major-version annotations and the PR Guard ordering note.
+- Update the durable AI PR workflow documentation to name the v7 pin used for
+  trusted gate scripts.
+
+## Non-goals
+
+- Change checkout topology, workflow permissions, or gate behavior.
+- Update unrelated GitHub Actions dependencies.

--- a/specs/017-checkout-v7-workflow-contract/tasks.md
+++ b/specs/017-checkout-v7-workflow-contract/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] Upgrade all workflow checkout pins and annotations to v7.0.1.
+- [x] Record the trusted-gate checkout contract in durable documentation.
+- [x] Run local validation; pull-request gates are pending publication.


### PR DESCRIPTION
Updates every pinned actions/checkout reference to v7.0.1, corrects workflow annotations, and records the trusted gate-checkout contract.

Local validation: `pnpm run ci`

Co-authored-by: Codex <codex@openai.com>