### PR TITLE
fix: document setup-node v7 workflow contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           cache: "pnpm"

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -130,7 +130,7 @@ jobs:
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           cache: "pnpm"

--- a/docs_dreamboard/project/devops/ai-pr-workflow.md
+++ b/docs_dreamboard/project/devops/ai-pr-workflow.md
@@ -49,6 +49,8 @@ This is the canonical PR loop for `dreamboard`.
   pinned `actions/checkout` v7 with explicit `ref:`. PR Guard uses a two-checkout pattern
   (`.gate-trusted/` for trusted scripts, workspace root for PR content), so a
   PR cannot tamper with gate logic to bypass required checks.
+- CI and PR Guard pin `actions/setup-node` v7 and explicitly select Node 24,
+  matching the repository's declared Node 24.8-or-newer runtime policy.
 
 ## Review Contract
 

--- a/specs/018-setup-node-v7-workflow-contract/plan.md
+++ b/specs/018-setup-node-v7-workflow-contract/plan.md
@@ -1,0 +1,5 @@
+# Plan
+
+1. Update the two pinned setup-node references to v7.0.0.
+2. Document that the CI and PR Guard runtime remains Node 24.
+3. Validate the repository baseline before publishing the pull request.

--- a/specs/018-setup-node-v7-workflow-contract/spec.md
+++ b/specs/018-setup-node-v7-workflow-contract/spec.md
@@ -1,0 +1,17 @@
+# Setup Node v7 workflow contract
+
+## Goal
+
+Upgrade the CI and PR Guard Node setup action to v7 while keeping the workflow
+runtime aligned with the repository's Node 24 policy.
+
+## Scope
+
+- Pin `actions/setup-node` v7.0.0 in CI and PR Guard.
+- Retain the explicit Node 24 selection used by both workflows.
+- Record the action/runtime relationship in the durable AI PR workflow guide.
+
+## Non-goals
+
+- Change the declared Node engine or selected Node major.
+- Modify dependency installation, cache behavior, or workflow permissions.

--- a/specs/018-setup-node-v7-workflow-contract/tasks.md
+++ b/specs/018-setup-node-v7-workflow-contract/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] Upgrade CI and PR Guard to the setup-node v7.0.0 pin.
+- [x] Document the Node 24 workflow runtime contract.
+- [x] Run local validation; pull-request gates are pending publication.


### PR DESCRIPTION
Pins CI and PR Guard to actions/setup-node v7.0.0 and records the Node 24 workflow runtime contract.

Local validation: `pnpm run ci`

Co-authored-by: Codex <codex@openai.com>