### PR TITLE
feat: adopt black pill button standard and centre hero copy

### DIFF
--- a/docs_dreamboard/project/frontend/frontend-docs.md
+++ b/docs_dreamboard/project/frontend/frontend-docs.md
@@ -58,6 +58,7 @@ How it is applied:
 
 - text buttons take the full standard: the landing CTA (`.cta-btn`), the editor sidebar tools (global `button`, `.control-group button`, `.file-input-label`), and the donate link (`.donate-matecito-link`); none of them carries a shadow, glow or gradient
 - icon-only buttons keep their compact size (44px back control, 40px object-menu tools) and take the black fill, white glyph and full rounding; the transparent text tools (`.om-texttool-btn`, `.om-color-btn`) draw their glyph in `--btn-bg` and get a light grey hover fill
+- the rotated portrait editor rail is only about 137px wide, so its three sidebar tools keep the 58px pill but drop to 12px type with 10px side padding so the labels fit without wrapping
 - three controls keep a non-black fill but take the pill shape: the font picker `#om-fontFamilyBtn` (a value control that must show the current font name, stays white) and the close buttons on the two dark glass overlays (rotate hint, donate modal, stay translucent white)
 - hover and active are background swaps, never opacity, so the old `button:hover { opacity }` idiom is gone
 - `--pantone-yellow` now only colours the slide-3 star bullets; `--volcanic-grass` only the slide-3 title and the font-popup check icon

--- a/docs_dreamboard/project/frontend/frontend-docs.md
+++ b/docs_dreamboard/project/frontend/frontend-docs.md
@@ -40,7 +40,29 @@ Hero slides 1 and 4 no longer use a photo background. `hero-mountains.js` mounts
 
 To regenerate the tone source from a new artwork, downscale it with `sips -s format jpeg -s formatOptions 72 -Z 1200 <source> --out src/assets/images/landing/hero-mountains-halftone.jpg`; only luminance matters, so a small JPEG is enough.
 
-Hero copy is centred and starts `clamp(24px, 10vh, 140px)` below the fixed header; the hero sections always reserve `--landing-header-h` on top, including the phone layout where other slides flatten their padding, so a short landscape viewport does not push the headline under the brand controls.
+Hero copy (title + CTA) is one block centred vertically on the slide with a small upward bias, `padding-bottom: clamp(24px, 8vh, 96px)` on desktop and `clamp(60px, 18vh, 160px)` below 900px, so on a portrait phone the button stays above the mountain skyline (the band takes 62% of the height there). The hero sections always reserve `--landing-header-h` on top, including the phone layout where other slides flatten their padding, so a short landscape viewport does not push the headline under the brand controls.
+
+## Button standard
+
+Since spec `022-black-pill-button-standard` (2026-09-02) the site has one button: a plain black pill, larger and more elongated than the old yellow CTA. The client picked it from a local matrix of 5 radii x 4 sizes (variant 01, "Pill · S"). The standard lives in `:root` as `--btn-*` tokens in `app.css`:
+
+| Token                                                  | Value                                                |
+| ------------------------------------------------------ | ---------------------------------------------------- |
+| `--btn-bg` / `--btn-bg-hover` / `--btn-bg-active`      | `#1b1b1b` (the hero-dot ink) / `#2e2e2e` / `#111111` |
+| `--btn-fg`                                             | `#ffffff`                                            |
+| `--btn-radius`                                         | `999px`                                              |
+| `--btn-height` / `--btn-min-width` / `--btn-padding-x` | `58px` / `160px` / `28px`                            |
+| `--btn-font-size` / `--btn-font-weight`                | `14px` / `800`, DM Sans, uppercase                   |
+
+How it is applied:
+
+- text buttons take the full standard: the landing CTA (`.cta-btn`), the editor sidebar tools (global `button`, `.control-group button`, `.file-input-label`), and the donate link (`.donate-matecito-link`); none of them carries a shadow, glow or gradient
+- icon-only buttons keep their compact size (44px back control, 40px object-menu tools) and take the black fill, white glyph and full rounding; the transparent text tools (`.om-texttool-btn`, `.om-color-btn`) draw their glyph in `--btn-bg` and get a light grey hover fill
+- three controls keep a non-black fill but take the pill shape: the font picker `#om-fontFamilyBtn` (a value control that must show the current font name, stays white) and the close buttons on the two dark glass overlays (rotate hint, donate modal, stay translucent white)
+- hover and active are background swaps, never opacity, so the old `button:hover { opacity }` idiom is gone
+- `--pantone-yellow` now only colours the slide-3 star bullets; `--volcanic-grass` only the slide-3 title and the font-popup check icon
+
+Any new button starts from the tokens. A different size is a spec change, not a local override.
 
 ## Landing footer
 
@@ -82,9 +104,9 @@ The current static app now treats phone layouts as a separate editor mode:
 ## Brand Chrome
 
 The app has no wordmark of its own. Landing and editor both carry the studio
-chrome transplanted from `ember.ks-design.art`: a `ks·design · lab` tag and a
-`study 01 — dream board` tag, rendered as `.brand-mark` with `.brand-tag`
-children.
+chrome transplanted from `ember.ks-design.art`: a `ks·design · lab` tag and,
+on the landing only, a `study 02 — dream board` tag (renamed from `study 01`
+in spec 022), rendered as `.brand-mark` with `.brand-tag` children.
 
 The mark is a faithful copy of the Ember original, not a re-interpretation:
 
@@ -98,7 +120,8 @@ The mark is a faithful copy of the Ember original, not a re-interpretation:
 Layout differs by shell because the space does:
 
 - landing uses the Ember arrangement, both tags on one row, pushed apart
-- the editor sidebar stacks the tags and shrinks them, because the rail shares
+- the editor sidebar shows the `ks·design · lab` tag alone (spec 022 dropped
+  the study tag from the editor), stacked and shrunk, because the rail shares
   its width with the back control
 - below 360px the landing tags shrink so the row never wraps
 - the rotated portrait editor rail leaves roughly 104px for the mark, which no

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
             >
             · lab</span
           >
-          <span class="brand-tag brand-tag-study">study 01 — dream board</span>
+          <span class="brand-tag brand-tag-study">study 02 — dream board</span>
         </div>
       </header>
 
@@ -176,9 +176,6 @@
                   ><span class="visually-hidden"> </span>design</strong
                 >
                 · lab</span
-              >
-              <span class="brand-tag brand-tag-study"
-                >study 01 — dream board</span
               >
             </div>
             <div class="sidebar-header-actions">

--- a/specs/022-black-pill-button-standard/plan.md
+++ b/specs/022-black-pill-button-standard/plan.md
@@ -1,0 +1,63 @@
+# Plan: black pill button standard, centred hero, study 02
+
+## Evidence gathered before editing
+
+- `src/styles/app.css` has four button idioms: `.cta-btn` (yellow pill,
+  shadow), global `button` (volcanic grass, 20px radius, opacity hover),
+  `#t-download` (yellow), `.donate-matecito-link` (literal `#fedd00`)
+- `--border-radius: 8px` is declared and never read; left untouched, out of
+  scope
+- `--pantone-yellow` is also read by `.rules-list li::before` (slide-3 star
+  bullets), so the token stays after the CTA stops using it
+- `--volcanic-grass` is also read by `.rules-title` and
+  `.font-popup .font-check svg`, so it stays too
+- the global `button { padding: 12px }` reaches every icon button; the new
+  global rule sets horizontal padding only and every icon button already sets
+  `padding: 0` except `.donate-modal-close`, which gets it
+- `button:hover { opacity: 0.9 }` would fight the new background hover on the
+  transparent object-menu buttons, so the colour button and the font picker
+  get explicit hover fills
+- hero copy sits at `padding-top: clamp(24px, 10vh, 140px)` inside
+  `.hero-center` with `justify-content: flex-start`; the mountain band is
+  bottom-anchored and on phones takes 62% of the height, so plain centring
+  would drop the button onto the skyline on a 390 x 844 viewport
+- `study 01 — dream board` appears twice in `index.html` (landing header,
+  editor sidebar) and once in `frontend-docs.md`; specs/015 is history and is
+  left as is
+- `tests/` has no button or brand-tag coverage; the gates are
+  `check-static-baseline`, `html-validate`, `build`, `prettier`, feature
+  memory and docs coverage
+
+## Steps
+
+1. Add the `--btn-*` tokens to `:root` with a comment recording the decision.
+2. Rebuild `.cta-btn` on the tokens: 58px, min-width 160px, pill, black, white
+   text, no shadow, background hover and active.
+3. Rebuild the global `button` rule and `.file-input-label` on the tokens;
+   give `.control-group button` the standard min-height; delete the
+   `#t-download` yellow override.
+4. Move the icon buttons (`.editor-home-btn`, `.om-btn`, `.om-icon-btn`,
+   `.om-color-btn`, `.om-texttool-btn`) to the black fill / ink glyph colour
+   and `--btn-radius`; keep their sizes.
+5. Pill the font picker and the two glass-overlay close buttons via
+   `--btn-radius`, keep their fills, add explicit hover fills where the global
+   hover would leak.
+6. Rebuild `.donate-matecito-link` on the tokens.
+7. Replace the mobile radius overrides (`24px`, `14px`) with `--btn-radius`.
+8. Centre `.landing-section.bg-hero .hero-center` with
+   `padding-bottom: clamp(24px, 8vh, 96px)`; below 900px use
+   `clamp(60px, 18vh, 160px)` so the phone button clears the skyline.
+9. `index.html`: drop the editor study tag, rename the landing tag to
+   `study 02 — dream board`.
+10. Update `frontend-docs.md`: button standard section, hero placement line,
+    brand chrome paragraph.
+11. Verify in the browser at 1440 x 900 and 390 x 844, then run
+    `pnpm run preflight`.
+
+## Risk
+
+Low to medium. The global `button` rule changes padding and hover for every
+button, so each icon button was checked for an explicit `padding: 0` and an
+explicit hover fill. Layout of the object menu and sidebar is unchanged
+because heights stay the same (40px tools, 44px back) or only grow inside a
+column that already stretches (sidebar tools 58px).

--- a/specs/022-black-pill-button-standard/spec.md
+++ b/specs/022-black-pill-button-standard/spec.md
@@ -1,0 +1,85 @@
+# Spec: black pill button standard, centred hero, study 02
+
+## Goal
+
+Make one button the standard for the whole site, landing and editor alike: a
+plain black pill, larger and more elongated than the current yellow CTA. Fix
+that standard in design tokens. In the same slice, drop the hero copy on slides
+1 and 4 so title and button read as one centred block, keep only the
+`ks·design · lab` tag in the editor, and rename the landing study tag to
+`study 02 — dream board`.
+
+## Background
+
+The landing CTA was a 54px Pantone-yellow pill with a drop shadow, the editor
+used a separate `--volcanic-grass` button style with a 20px radius, the
+download button was yellow, and the donate link was yet another yellow pill.
+Four button idioms for one small app.
+
+The client reviewed four local galleries (30 colour harmonies, opaque glass,
+backlit frosted glass, Reboot-style light bar, then a plain-black matrix of
+5 radii x 4 sizes) and picked plain-black matrix variant 01, "Pill · S":
+`160 x 58px`, radius `999px`, `#1b1b1b`, white 14px/800 uppercase text, no
+shadow, hover `#2e2e2e`. Decision date 2026-09-02.
+
+## Scope
+
+- add `--btn-*` tokens to `:root` in `src/styles/app.css` and rebuild
+  `.cta-btn`, the global `button` rule, `.file-input-label`, `#t-download`,
+  `.editor-home-btn`, `.object-menu .om-btn`, `#om-fontFamilyBtn`,
+  `.om-texttool-btn`, `.om-color-btn`, `.editor-rotate-close`,
+  `.donate-modal-close`, `.donate-matecito-link` and the mobile overrides on
+  those tokens
+- centre the hero block on slides 1 and 4 (`.landing-section.bg-hero
+.hero-center`), with a larger upward bias on phones so the button stays above
+  the mountain skyline
+- `index.html`: remove the study tag from the editor sidebar brand mark; rename
+  the landing tag to `study 02 — dream board`
+- update `docs_dreamboard/project/frontend/frontend-docs.md`
+
+## Button standard
+
+| Token             | Value     | Meaning                                           |
+| ----------------- | --------- | ------------------------------------------------- |
+| `--btn-bg`        | `#1b1b1b` | fill, the same ink as the hero dots               |
+| `--btn-bg-hover`  | `#2e2e2e` | hover fill                                        |
+| `--btn-bg-active` | `#111111` | pressed fill                                      |
+| `--btn-fg`        | `#ffffff` | text and icon colour                              |
+| `--btn-radius`    | `999px`   | full pill on every button, circle on icon buttons |
+| `--btn-height`    | `58px`    | text buttons                                      |
+| `--btn-min-width` | `160px`   | text buttons, keeps short labels elongated        |
+| `--btn-padding-x` | `28px`    | text buttons                                      |
+| `--btn-font-size` | `14px`    | DM Sans 800 uppercase                             |
+
+Rules:
+
+- every text button (landing CTA, sidebar tools, donate link) takes the full
+  standard: black pill, 58px tall, at least 160px wide, no shadow, no glow
+- icon-only buttons (editor back, object-menu tools) keep their compact size
+  and take the black fill and full rounding
+- two exceptions keep a non-black fill but take the pill shape: the font
+  picker (`#om-fontFamilyBtn`, a value control that must show the current font
+  name) and the close buttons on the two dark glass overlays (rotate hint,
+  donate modal), where a black fill would vanish against the panel
+- `--pantone-yellow` stays only for the star bullets on slide 3;
+  `--volcanic-grass` stays for the slide-3 title and popup check icons
+
+## Non-Goals
+
+- no change to button copy, ids, or JavaScript behaviour
+- no change to the dotted-mountain canvas, footer, or brand mark typography
+- no redesign of the object menu layout or the font popup list
+
+## Acceptance Criteria
+
+1. No button on the landing or in the editor renders a colour other than
+   `--btn-bg` / `--btn-bg-hover` / `--btn-bg-active`, except the three
+   documented exceptions; every button has `border-radius: 999px`.
+2. The landing CTA measures 160 x 58px with a short label and has no
+   box-shadow.
+3. On slides 1 and 4 the title + button block is vertically centred on
+   desktop; on a 390 x 844 phone the button sits above the mountain skyline.
+4. The editor sidebar shows only `ks·design · lab`; the landing header shows
+   `ks·design · lab` and `study 02 — dream board`; no `study 01` string remains
+   in `index.html` or `src/`.
+5. `pnpm run preflight` is green and frontend docs describe the standard.

--- a/specs/022-black-pill-button-standard/tasks.md
+++ b/specs/022-black-pill-button-standard/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: black pill button standard, centred hero, study 02
+
+- [x] Review the four local galleries with the client and record the pick
+      (plain-black matrix, variant 01 "Pill · S") in `spec.md`
+- [x] Inventory every button rule in `src/styles/app.css` and every reader of
+      `--pantone-yellow` / `--volcanic-grass`
+- [x] Add the `--btn-*` tokens to `:root`
+- [x] Rebuild `.cta-btn`, global `button`, `.file-input-label`,
+      `.control-group button`; delete the `#t-download` override
+- [x] Move icon buttons and the object menu to the black fill and pill radius
+- [x] Pill the font picker and the glass-overlay close buttons, keep fills
+- [x] Rebuild `.donate-matecito-link` on the tokens
+- [x] Replace mobile radius overrides with `--btn-radius`
+- [x] Centre the hero block on slides 1 and 4 with a phone-specific bias
+- [x] `index.html`: editor shows only `ks·design · lab`; landing tag is
+      `study 02 — dream board`
+- [x] Update `docs_dreamboard/project/frontend/frontend-docs.md`
+- [x] Verify landing (desktop + phone) and editor in the browser
+- [x] Run `pnpm run preflight`
+- [ ] Open the PR and drive it to merge-ready

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -837,6 +837,7 @@ body.is-editor-restoring .object-menu {
   display: flex;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
   min-height: var(--btn-height);
   padding: 0 var(--btn-padding-x);
   background: var(--btn-bg);
@@ -1789,6 +1790,7 @@ body.is-editor-active .app-container {
   align-items: center;
   justify-content: center;
   gap: 0;
+  box-sizing: border-box; /* an <a>, so the 160px minimum must include padding */
   min-height: var(--btn-height);
   min-width: var(--btn-min-width);
   padding: 0 var(--btn-padding-x);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9,6 +9,21 @@
   --editor-shell-gap: 20px;
   --editor-mobile-sheet-gap: 16px;
 
+  /* Button standard (spec 022, 2026-09-02): every button on the site, landing
+     and editor alike, is one black pill. Picked from the plain-black matrix,
+     variant 01 "Pill · S". Icon-only buttons keep their compact size but take
+     the same fill and full rounding. */
+  --btn-bg: #1b1b1b; /* the same ink as the hero dots */
+  --btn-bg-hover: #2e2e2e;
+  --btn-bg-active: #111111;
+  --btn-fg: #ffffff;
+  --btn-radius: 999px;
+  --btn-height: 58px;
+  --btn-min-width: 160px;
+  --btn-padding-x: 28px;
+  --btn-font-size: 14px;
+  --btn-font-weight: 800;
+
   --landing-bg: #ececec;
   --landing-bg-2: #f3f3f3;
   --landing-text-dark: #2b2b2b;
@@ -247,11 +262,20 @@ html[data-initial-view="editor"] .sticky-footer {
   margin-top: 26px;
 }
 
-/* Hero slides: the text block sits in the free sky above the mountains */
+/* Hero slides: title + button read as one block centred on the slide, nudged
+   up a little so it sits in the sky rather than on the mountain band. Phones
+   get a larger bias because the band takes 62% of a portrait viewport. */
 .landing-section.bg-hero .hero-center {
-  justify-content: flex-start;
+  justify-content: center;
   align-items: center;
-  padding-top: clamp(24px, 10vh, 140px);
+  padding-top: 0;
+  padding-bottom: clamp(24px, 8vh, 96px);
+}
+
+@media (max-width: 900px) {
+  .landing-section.bg-hero .hero-center {
+    padding-bottom: clamp(60px, 18vh, 160px);
+  }
 }
 
 .landing-section.bg-hero .hero-title {
@@ -424,24 +448,28 @@ html[data-initial-view="editor"] .sticky-footer {
 }
 
 .cta-btn {
-  height: 54px;
-  padding: 0 26px;
-  border-radius: 999px;
+  height: var(--btn-height);
+  min-width: var(--btn-min-width);
+  padding: 0 var(--btn-padding-x);
+  border-radius: var(--btn-radius);
   border: none;
-  background: var(--pantone-yellow);
-  color: #000;
-  font-weight: 800;
+  background: var(--btn-bg);
+  color: var(--btn-fg);
+  font-weight: var(--btn-font-weight);
   font-family: "DM Sans", sans-serif;
-  font-size: 14px;
+  font-size: var(--btn-font-size);
   cursor: pointer;
   text-transform: uppercase;
-  box-shadow:
-    0 10px 28px rgba(0, 0, 0, 0.1),
-    0 2px 6px rgba(0, 0, 0, 0.08);
+  box-shadow: none;
+  transition: background-color 0.2s ease;
 }
 
 .cta-btn:hover {
-  opacity: 0.95;
+  background: var(--btn-bg-hover);
+}
+
+.cta-btn:active {
+  background: var(--btn-bg-active);
 }
 
 .hero-visual {
@@ -673,13 +701,11 @@ html[data-initial-view="editor"] .sticky-footer {
   min-width: 44px;
   height: 44px;
   padding: 0;
-  border-radius: 22px;
-  border: 1px solid #ececec;
-  background: #fff;
-  color: var(--volcanic-grass);
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.08),
-    0 2px 8px rgba(0, 0, 0, 0.08);
+  border-radius: var(--btn-radius);
+  border: none;
+  background: var(--btn-bg);
+  color: var(--btn-fg);
+  box-shadow: none;
 }
 
 .editor-home-btn svg {
@@ -743,28 +769,31 @@ html[data-initial-view="editor"] .sticky-footer {
   border-bottom: 1px solid #eee;
 }
 
-/* Стили кнопок */
+/* Buttons: the one black pill standard (see --btn-* tokens) */
 button {
-  padding: 12px;
-  border-radius: 20px;
+  padding: 0 var(--btn-padding-x);
+  border-radius: var(--btn-radius);
   border: none;
-  background: var(--volcanic-grass);
-  color: #fff;
+  background: var(--btn-bg);
+  color: var(--btn-fg);
   cursor: pointer;
-  transition: opacity 0.2s;
-  font-size: 12px;
-  font-weight: 700;
+  transition: background-color 0.2s ease;
+  font-size: var(--btn-font-size);
+  font-weight: var(--btn-font-weight);
   font-family: "DM Sans", sans-serif;
   text-transform: uppercase;
 }
 
 button:hover {
-  opacity: 0.9;
+  background: var(--btn-bg-hover);
 }
 
-#t-download {
-  background: var(--pantone-yellow);
-  color: #000;
+button:active {
+  background: var(--btn-bg-active);
+}
+
+.control-group button {
+  min-height: var(--btn-height);
 }
 
 .canvas-area {
@@ -805,16 +834,24 @@ body.is-editor-restoring .object-menu {
 }
 
 .file-input-label {
-  display: block;
-  padding: 12px;
-  background: var(--volcanic-grass);
-  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--btn-height);
+  padding: 0 var(--btn-padding-x);
+  background: var(--btn-bg);
+  color: var(--btn-fg);
   text-align: center;
-  border-radius: 20px;
+  border-radius: var(--btn-radius);
   cursor: pointer;
-  font-weight: 700;
-  font-size: 12px;
+  font-weight: var(--btn-font-weight);
+  font-size: var(--btn-font-size);
   text-transform: uppercase;
+  transition: background-color 0.2s ease;
+}
+
+.file-input-label:hover {
+  background: var(--btn-bg-hover);
 }
 
 /* Контекстное меню объекта (Material Design 3 styling) */
@@ -852,12 +889,12 @@ body.is-editor-restoring .object-menu {
 .object-menu .om-btn {
   height: 40px;
   padding: 0 16px;
-  border-radius: 20px;
+  border-radius: var(--btn-radius);
   border: none;
-  background: var(--volcanic-grass);
-  color: #fff;
+  background: var(--btn-bg);
+  color: var(--btn-fg);
   cursor: pointer;
-  transition: opacity 0.2s;
+  transition: background-color 0.2s ease;
   font-size: 12px;
   font-weight: 700;
   font-family: "DM Sans", sans-serif;
@@ -870,7 +907,7 @@ body.is-editor-restoring .object-menu {
 }
 
 .object-menu .om-btn:hover {
-  opacity: 0.9;
+  background: var(--btn-bg-hover);
 }
 
 .object-menu .om-icon-btn {
@@ -887,11 +924,13 @@ body.is-editor-restoring .object-menu {
 }
 
 /* (1) кнопка выбора шрифта */
+/* value control, not an action: pill shape, but keeps the white fill so the
+   current font name stays readable */
 #om-fontFamilyBtn {
   height: 40px;
   padding-left: 12px;
   padding-right: 12px;
-  border-radius: 20px;
+  border-radius: var(--btn-radius);
   border: 1px solid #ddd;
   font-size: 14px;
   font-family: "DM Sans", sans-serif;
@@ -909,7 +948,7 @@ body.is-editor-restoring .object-menu {
 }
 
 #om-fontFamilyBtn:hover {
-  opacity: 1;
+  background: #fff;
 }
 
 #om-fontFamilyBtn .om-font-label {
@@ -968,12 +1007,12 @@ body.is-editor-restoring .object-menu {
 
 .om-texttool-btn {
   background: transparent !important;
-  color: var(--volcanic-grass) !important;
+  color: var(--btn-bg) !important;
   opacity: 1 !important;
 }
 
 .om-texttool-btn:hover {
-  opacity: 1 !important;
+  background: rgba(120, 120, 120, 0.12) !important;
 }
 
 .om-texttool-btn.is-selected {
@@ -985,10 +1024,10 @@ body.is-editor-restoring .object-menu {
   min-width: 40px;
   height: 40px;
   padding: 0;
-  border-radius: 20px;
+  border-radius: var(--btn-radius);
   border: none;
   background: transparent;
-  color: var(--volcanic-grass);
+  color: var(--btn-bg);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -998,6 +1037,10 @@ body.is-editor-restoring .object-menu {
   font-weight: 900;
   font-family: "DM Sans", sans-serif;
   text-transform: none;
+}
+
+.om-color-btn:hover {
+  background: rgba(120, 120, 120, 0.12);
 }
 
 .om-color-btn::before {
@@ -1225,7 +1268,7 @@ body.is-editor-active .sticky-footer {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
+  border-radius: var(--btn-radius);
   border: none;
   background: rgba(255, 255, 255, 0.12);
   color: rgba(255, 255, 255, 0.94);
@@ -1388,9 +1431,7 @@ body.is-editor-active .app-container {
 
   .control-group button,
   .file-input-label {
-    min-height: 48px;
-    border-radius: 24px;
-    font-size: 13px;
+    border-radius: var(--btn-radius);
   }
 
   .canvas-wrapper {
@@ -1579,7 +1620,7 @@ body.is-editor-active .app-container {
   body.is-editor-active .sidebar .file-input-label {
     min-height: 0;
     height: auto;
-    border-radius: 14px;
+    border-radius: var(--btn-radius);
     font-size: 11px;
     padding: 6px 10px;
     line-height: 1.2;
@@ -1696,10 +1737,11 @@ body.is-editor-active .app-container {
   right: 14px;
   width: 44px;
   height: 44px;
+  padding: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
+  border-radius: var(--btn-radius);
   appearance: none;
   border: none;
   background: rgba(255, 255, 255, 0.1);
@@ -1747,32 +1789,27 @@ body.is-editor-active .app-container {
   align-items: center;
   justify-content: center;
   gap: 0;
-  min-height: 44px;
-  padding: 0 18px;
-  border-radius: 999px;
-  font-weight: 800;
-  font-size: 16px; /* крупнее */
-  letter-spacing: 0.2px;
+  min-height: var(--btn-height);
+  min-width: var(--btn-min-width);
+  padding: 0 var(--btn-padding-x);
+  border-radius: var(--btn-radius);
+  font-weight: var(--btn-font-weight);
+  font-size: var(--btn-font-size);
+  text-transform: uppercase;
   border: none;
-  color: rgba(36, 36, 37, 1);
-  background: #fedd00; /* Pantone Yellow C (approx) */
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.25);
-  transition:
-    transform 0.12s ease,
-    filter 0.12s ease,
-    box-shadow 0.12s ease;
+  color: var(--btn-fg);
+  background: var(--btn-bg);
+  box-shadow: none;
+  transition: background-color 0.2s ease;
   text-decoration: none;
   user-select: none;
   -webkit-tap-highlight-color: transparent;
 }
 .donate-matecito-link:hover {
-  filter: brightness(0.98);
-  transform: translateY(-1px);
-  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.28);
+  background: var(--btn-bg-hover);
 }
 .donate-matecito-link:active {
-  transform: translateY(0px);
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.25);
+  background: var(--btn-bg-active);
 }
 
 /* hide legacy embed assets, keep only text */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -911,6 +911,10 @@ body.is-editor-restoring .object-menu {
   background: var(--btn-bg-hover);
 }
 
+.object-menu .om-btn:active {
+  background: var(--btn-bg-active);
+}
+
 .object-menu .om-icon-btn {
   width: 40px;
   min-width: 40px;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -948,7 +948,8 @@ body.is-editor-restoring .object-menu {
   cursor: pointer;
 }
 
-#om-fontFamilyBtn:hover {
+#om-fontFamilyBtn:hover,
+#om-fontFamilyBtn:active {
   background: #fff;
 }
 
@@ -1042,6 +1043,10 @@ body.is-editor-restoring .object-menu {
 
 .om-color-btn:hover {
   background: rgba(120, 120, 120, 0.12);
+}
+
+.om-color-btn:active {
+  background: rgba(120, 120, 120, 0.2);
 }
 
 .om-color-btn::before {
@@ -1279,6 +1284,10 @@ body.is-editor-active .sticky-footer {
 .editor-rotate-close:hover {
   opacity: 1;
   background: rgba(255, 255, 255, 0.18);
+}
+
+.editor-rotate-close:active {
+  background: rgba(255, 255, 255, 0.24);
 }
 
 .editor-rotate-close svg {
@@ -1756,6 +1765,7 @@ body.is-editor-active .app-container {
   transform: scale(1.03);
 }
 .donate-modal-close:active {
+  background: rgba(255, 255, 255, 0.22);
   transform: scale(0.98);
 }
 .donate-modal-close svg {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1630,17 +1630,19 @@ body.is-editor-active .app-container {
     gap: 8px;
   }
 
+  /* The rail is only ~137px wide, so the labels get smaller type and side
+     padding, but the tools keep the standard 58px pill. */
   body.is-editor-active .sidebar .control-group button,
   body.is-editor-active .sidebar .file-input-label {
-    min-height: 0;
-    height: auto;
-    border-radius: var(--btn-radius);
-    font-size: 11px;
-    padding: 6px 10px;
+    min-height: var(--btn-height);
+    padding: 0 10px;
+    font-size: 12px;
     line-height: 1.2;
     letter-spacing: -0.2px;
     white-space: normal;
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     text-align: center;
   }
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -855,6 +855,10 @@ body.is-editor-restoring .object-menu {
   background: var(--btn-bg-hover);
 }
 
+.file-input-label:active {
+  background: var(--btn-bg-active);
+}
+
 /* Контекстное меню объекта (Material Design 3 styling) */
 .object-menu {
   position: absolute;
@@ -1019,6 +1023,10 @@ body.is-editor-restoring .object-menu {
 
 .om-texttool-btn:hover {
   background: rgba(120, 120, 120, 0.12) !important;
+}
+
+.om-texttool-btn:active {
+  background: rgba(120, 120, 120, 0.2) !important;
 }
 
 .om-texttool-btn.is-selected {


### PR DESCRIPTION
## Summary

- one button for the whole site: plain black pill `#1b1b1b`, 160 × 58 px, radius 999, white 14/800 uppercase text, no shadow, hover `#2e2e2e`; fixed as `--btn-*` design tokens in `app.css` (spec `022-black-pill-button-standard`, client pick from the plain-black matrix, variant 01 "Pill · S")
- landing CTA, editor sidebar tools, download button and donate link take the full standard; icon buttons (editor back, object-menu tools) keep their compact size and take the black fill and full rounding; font picker and the two glass-overlay close buttons keep their fill but take the pill shape
- hero copy on slides 1 and 4 is now one block centred on the slide (small upward bias on desktop, larger on phones so the button stays above the mountain skyline)
- editor sidebar shows only `ks·design · lab`; landing study tag renamed to `study 02 — dream board`
- frontend docs: new "Button standard" section, hero placement and brand chrome paragraphs updated

## Verification

- `pnpm run preflight` green (feature memory, baseline, html-validate, build, prettier, 27 tests)
- browser at 1440 × 900: CTA measures 160 × 58, radius 999, no shadow; title + button block centred; header tags `ks·design · lab` / `study 02 — dream board`
- browser at 375 × 812: title and button sit above the skyline (button bottom at 409 px, first ridge at ~455 px)
- editor: sidebar buttons 58 px black pills, back control 44 px black circle, object-menu tools 40 px black circles, text tools ink glyphs on transparent, font picker white pill; sidebar brand shows the lab tag only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
