### PR TITLE
fix: fit the phone canvas to the visible viewport

### DIFF
--- a/docs_dreamboard/project/frontend/frontend-docs.md
+++ b/docs_dreamboard/project/frontend/frontend-docs.md
@@ -97,6 +97,8 @@ The editor now uses container-based canvas sizing instead of raw viewport math:
 - the editor shell owns the available space; on desktop the `.canvas-stage` column holds `.canvas-area` above the editor footer
 - the Fabric canvas resizes from the `.canvas-area` container
 - a `ResizeObserver` keeps the canvas in sync with footer height and viewport changes
+- on a phone the canvas takes the measured `.canvas-area` box with no minimum above it (a 120px floor only guards a degenerate measurement); the canvas owns every touch through `touch-action: none`, so anything laid out past the visible column could never be scrolled into view, which is why the phone canvas fits rather than scrolls (spec 024); desktop keeps its 420 x 520 working minimum and the `.canvas-stage` scroll
+- the phone editor shell is sized from `--editor-vw` / `--editor-vh`, set by `updateEditorViewportVars()` from `innerWidth` / `innerHeight` at boot and on every `syncEditorViewport` call, with `100dvw` / `100dvh` as CSS fallbacks: in-app browsers and Safari with a collapsible toolbar can report a `100dvh` taller than the visible area, which put the far end of the canvas under the toolbar on an iPhone 15 Pro Max; `innerHeight` is the visible layout viewport everywhere and, unlike `visualViewport`, does not shrink for the iOS keyboard
 - the mobile editor now uses a dedicated interaction shell instead of a desktop left rail squeezed into phone width
 
 ## Mobile Editor Model
@@ -106,8 +108,9 @@ The current static app now treats phone layouts as a separate editor mode:
 - the mobile editor chrome lives in the permanently visible sidebar rail; there is no separate mobile top bar
 - tool controls sit in that always-on rail, so there is no burger button, bottom sheet or off-canvas drawer to open
 - back to the landing page is reachable from the sidebar header
-- the phone editor has no footer line; the canvas reserves the device safe-area insets
-- the object menu docks near the bottom of the canvas on mobile instead of chasing the selected object into cramped positions
+- the phone editor has no footer line; the canvas reserves the device safe-area insets, and in the rotated portrait shell the insets follow the screen rather than the box: the screen-top inset pads the rail's left edge (the rail grows by it) and the screen-bottom inset pads the canvas column's right edge
+- the rotated portrait shell is laid out `--editor-vh` wide and `--editor-vw` tall with `min-height: 0`, then turned a quarter clockwise; the base `.editor-view` floor of `100dvh` used to win over that height, made the box square and pushed `100dvh - 100dvw` of the canvas off the left of the screen (spec 024)
+- the object menu docks near the bottom of the canvas on mobile instead of chasing the selected object into cramped positions; the dock and the font / colour popups are placed from local wrapper geometry (`canvas.getWidth()` / `getHeight()` and `offsetLeft` / `offsetTop` / `offsetWidth` / `offsetHeight`, shared through `positionAnchoredPopup()`), because client rects swap width and height inside the rotated shell; the dock drag already converted its deltas the same way
 - portrait phone editor remains usable; landscape is now a recommendation surfaced through a non-blocking floating hint card instead of a hard gate, because mobile web orientation locks are not reliable enough to block entry
 - phone landscape switches into a true side-by-side shell so the tools and canvas use the wider viewport instead of reusing the portrait bottom-sheet layout
 - editor return controls are icon-only, with tooltips instead of visible labels to keep the shell visually lighter

--- a/specs/024-mobile-canvas-fit-visible-viewport/plan.md
+++ b/specs/024-mobile-canvas-fit-visible-viewport/plan.md
@@ -1,0 +1,51 @@
+# Plan: phone canvas fits the visible viewport
+
+## Evidence gathered before editing
+
+- `main` at 430 x 714 (`#editor`, browser pane): `.editor-view` client rect
+  `x: -284, w: 714, h: 714`; `.canvas-container` `x: -270, w: 686, h: 507`;
+  Fabric canvas 507 x 686. The `min-height: 100dvh` of the base
+  `.editor-view` wins over the rotated rule's `height: 100dvw`.
+- `getCanvasTargetSize()` floors phones at 280 x 360; the rotated column is
+  `innerWidth - 28` tall, 347px on a 375px phone.
+- `positionObjectMenu()` mobile branch: `canvasRect.width` 402 /
+  `canvasRect.height` 507 (screen space) for a 507 x 402 canvas; the dock
+  landed at `left: 145; top: 111` and ran 22px past the canvas' right edge.
+- The drag handler (`toLocalDelta`) already converts screen deltas for the
+  rotated shell, so it stays as is.
+- Browser pane caveat: a hidden pane tab fires neither `requestAnimationFrame`
+  nor `ResizeObserver`, so the canvas reads its 960 x 640 default until the
+  tab is fronted and painted (a screenshot forces a frame); the popups also
+  position inside `requestAnimationFrame`.
+
+## Steps
+
+1. `app.js`: add `updateEditorViewportVars()`; call it first in
+   `syncEditorViewport()` and once at boot.
+2. `app.js`: split `getCanvasTargetSize()` into the phone fit (120px floor)
+   and the desktop 420 x 520 minimum.
+3. `app.js`: add `getLocalCanvasSize()` / `getLocalRect()`; fold the two
+   popup positioners into `positionAnchoredPopup(popup, anchorButton)`;
+   switch the mobile dock branch to local geometry and move the client-rect
+   reads into the desktop branch.
+4. `app.css`: point the phone editor heights at `var(--editor-vh, 100dvh)`;
+   in the rotated block set `min-height: 0`, size and translate from the two
+   vars, move the safe-area insets to the screen's edges, cap the wrapper
+   height at `var(--editor-vw, 100dvw) - 28px`.
+5. Verify at 430 x 714, 375 x 667, 844 x 390 and 1440 x 900; with a text
+   selected, check the dock and the font popup at 430 x 714.
+6. Update `frontend-docs.md`; run `pnpm run preflight`; open the PR for the
+   on-device check on the stage preview.
+
+## Risk
+
+Low to medium. The CSS custom properties fall back to the previous `dvh` /
+`dvw` values, so a page without the script lays out as before. The phone
+floor change only lowers sizes on phones narrower than 388px in the rotated
+shell or shorter than 388px in landscape. The popup refactor keeps the same
+placement rule (below the menu when there is room, else above; centred on the
+anchor button; clamped 10px inside the canvas) and only swaps the geometry
+source, which is identical to the old one when nothing is transformed, so the
+desktop menu is unchanged. Android Chrome shrinks `innerHeight` for the
+keyboard exactly as it shrank `dvh`, so keyboard behaviour there is
+unchanged.

--- a/specs/024-mobile-canvas-fit-visible-viewport/spec.md
+++ b/specs/024-mobile-canvas-fit-visible-viewport/spec.md
@@ -1,0 +1,101 @@
+# Spec: phone canvas fits the visible viewport
+
+## Goal
+
+On a phone the whole Fabric canvas is on screen, in both orientations, in
+Safari and in in-app browsers. Nothing of it runs under a toolbar or off an
+edge, and the object menu and its popups stay on the canvas too.
+
+## Background
+
+Reported on an iPhone 15 Pro Max in an in-app Safari view (2026-09-03): the
+far end of the canvas is cut off by the bottom toolbar and cannot be scrolled
+into view. Three causes were found on `main`:
+
+- In the rotated portrait shell (`(max-width: 900px) and (orientation:
+portrait)`), `body.is-editor-active .editor-view` sets `width: 100dvh;
+height: 100dvw` but inherits `min-height: 100dvh` from the base
+  `.editor-view`. The floor wins over the height, the box is `100dvh` square,
+  and after the quarter turn its far side sits `100dvh - 100dvw` off the left
+  of the screen. At 430 x 714 the canvas was 507 x 686 with 270px of it
+  outside the viewport.
+- The phone shell is sized from `dvh` / `dvw`. In-app browsers and Safari with
+  a collapsible toolbar can report a `100dvh` taller than the visible area, and
+  the canvas owns every touch (`touch-action: none`), so anything laid out past
+  the visible height has no way to scroll into view.
+- `getCanvasTargetSize()` floors the phone canvas at 280 x 360. In the
+  rotated shell the canvas height is the screen width minus 28px, which is
+  347px on a 375px phone, so the floor overflowed the column by 13px.
+- The mobile dock and the font / colour popups are positioned from
+  `getBoundingClientRect()`, whose width and height swap places inside the
+  rotated shell, so the dock landed mid-canvas and ran past its right edge.
+
+## Scope
+
+- `src/scripts/app.js`
+  - `updateEditorViewportVars()` writes `--editor-vw` / `--editor-vh` from
+    `innerWidth` / `innerHeight` at boot and from every `syncEditorViewport`
+    call (`resize`, `orientationchange`, `visualViewport.resize`, editor entry)
+  - `getCanvasTargetSize()` gives the phone canvas the measured column with
+    only a 120px degenerate-measurement floor; desktop keeps 420 x 520
+  - `positionObjectMenu()` (mobile branch), `positionColorPopup()` and
+    `positionFontPopup()` read local wrapper geometry (`canvas.getWidth()` /
+    `getHeight()`, `offsetLeft` / `offsetTop` / `offsetWidth` / `offsetHeight`)
+    through a shared `positionAnchoredPopup()`
+- `src/styles/app.css`
+  - phone editor (`<= 900px`, `body.is-editor-active`): `.app-container`
+    height, `.sidebar` max-height and `.canvas-wrapper` max-height read
+    `var(--editor-vh, 100dvh)`
+  - rotated portrait shell: `.editor-view` takes `width: var(--editor-vh,
+100dvh); height: var(--editor-vw, 100dvw); min-height: 0` and translates by
+    `var(--editor-vw, 100dvw)`; the sidebar carries the screen-top safe-area
+    inset on its left edge and grows by it; `.canvas-area` carries the
+    screen-bottom inset on its right edge; `.canvas-wrapper` is capped at
+    `var(--editor-vw, 100dvw) - 28px`
+- `docs_dreamboard/project/frontend/frontend-docs.md`
+
+## Decisions
+
+- Fit, not scroll. The canvas keeps `touch-action: none` so Fabric owns drags,
+  which means a scroll container around it can only be scrolled from the 14px
+  gutters. A canvas that always fits the visible column needs no scroll at
+  all, and the desktop keeps its existing `.canvas-stage` scroll for windows
+  shorter than the 520px minimum.
+- Measured viewport over `dvh`. `innerWidth` / `innerHeight` are the visible
+  layout viewport in every mobile browser and, unlike `visualViewport`, do not
+  shrink for the iOS keyboard, so an in-progress text edit does not resize the
+  canvas. `dvh` / `dvw` stay as CSS fallbacks for a page without the script.
+- Safe-area insets follow the screen. In the rotated shell the box's top edge
+  is the screen's right edge, so the previous top / bottom insets on the rail
+  and the column padded the wrong sides. The screen-top inset now pads the
+  rail's left edge, the screen-bottom inset the column's right edge.
+- Local geometry for the dock. Offsets against `.canvas-wrapper` describe the
+  same plane the menu is positioned in, in both orientations; client rects do
+  not once the wrapper is transformed. The existing drag handler already
+  converted deltas for the rotated shell, so the positioning now matches it.
+
+## Non-Goals
+
+- no change to the rotated-portrait approach itself (spec 002), to the rail
+  contents, or to the landscape shell layout
+- no scaling of restored draft objects to the new canvas size; object
+  coordinates stay absolute, as before
+- no change to the desktop editor
+
+## Acceptance Criteria
+
+1. At 430 x 714 in `#editor` the `.editor-view` box is 714 x 430 before the
+   turn (`min-height` computes `0px`), its client rect is exactly the
+   viewport, and the Fabric canvas is 507 x 402 with its container rect inside
+   `[14, 416] x [193, 700]`.
+2. At 375 x 667 the canvas is 461 x 347, entirely inside the viewport; no
+   phone size floors the canvas above the measured column.
+3. At 844 x 390 the canvas is 567 x 362 inside the viewport; at 1440 x 900 the
+   canvas is unchanged from `main` (1029 x 835, bottom at the footer top).
+4. At 430 x 714 with a text selected, the mobile dock lies along the far
+   (screen-left) edge of the canvas, centred on it, fully inside the canvas
+   rect; the font popup opens fully inside the canvas rect.
+5. `--editor-vw` / `--editor-vh` equal `innerWidth` / `innerHeight` after
+   boot and after a `resize` event.
+6. `pnpm run preflight` is green and the frontend docs describe the measured
+   viewport, the fit rule and the local dock geometry.

--- a/specs/024-mobile-canvas-fit-visible-viewport/spec.md
+++ b/specs/024-mobile-canvas-fit-visible-viewport/spec.md
@@ -49,9 +49,11 @@ height: 100dvw` but inherits `min-height: 100dvh` from the base
   - rotated portrait shell: `.editor-view` takes `width: var(--editor-vh,
 100dvh); height: var(--editor-vw, 100dvw); min-height: 0` and translates by
     `var(--editor-vw, 100dvw)`; the sidebar carries the screen-top safe-area
-    inset on its left edge and grows by it; `.canvas-area` carries the
-    screen-bottom inset on its right edge; `.canvas-wrapper` is capped at
-    `var(--editor-vw, 100dvw) - 28px`
+    inset in its left padding (content-box, so the rail grows by the inset
+    once); `.canvas-area` carries the screen-bottom inset on its right edge;
+    `.canvas-wrapper` is capped at `var(--editor-vw, 100dvw) - 28px`
+  - `.font-popup` is `border-box` with `max-height: min(320px, calc(100% -
+20px))`, so the picker never outgrows the fitted canvas it is positioned in
 - `docs_dreamboard/project/frontend/frontend-docs.md`
 
 ## Decisions
@@ -94,7 +96,8 @@ height: 100dvw` but inherits `min-height: 100dvh` from the base
    canvas is unchanged from `main` (1029 x 835, bottom at the footer top).
 4. At 430 x 714 with a text selected, the mobile dock lies along the far
    (screen-left) edge of the canvas, centred on it, fully inside the canvas
-   rect; the font popup opens fully inside the canvas rect.
+   rect; the font popup opens fully inside the canvas rect, and at 360 x 640
+   (canvas 332px tall) the popup is at most 312px tall and scrolls inside.
 5. `--editor-vw` / `--editor-vh` equal `innerWidth` / `innerHeight` after
    boot and after a `resize` event.
 6. `pnpm run preflight` is green and the frontend docs describe the measured

--- a/specs/024-mobile-canvas-fit-visible-viewport/tasks.md
+++ b/specs/024-mobile-canvas-fit-visible-viewport/tasks.md
@@ -12,4 +12,6 @@
       popup at 430 x 714
 - [x] Update `docs_dreamboard/project/frontend/frontend-docs.md`
 - [x] Run `pnpm run preflight`
+- [x] Codex round 1 (two P2): cap `.font-popup` at the fitted canvas height;
+      stop reserving the screen-top inset twice on the content-box rail
 - [ ] Open the PR and check the stage preview on the iPhone 15 Pro Max

--- a/specs/024-mobile-canvas-fit-visible-viewport/tasks.md
+++ b/specs/024-mobile-canvas-fit-visible-viewport/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: phone canvas fits the visible viewport
+
+- [x] Reproduce at 430 x 714 in the browser pane; measure the square
+      `.editor-view` and the off-screen canvas
+- [x] Trace the phone floors in `getCanvasTargetSize()` and the screen-space
+      dock geometry in `positionObjectMenu()`
+- [x] `app.js`: `updateEditorViewportVars()`, phone fit in
+      `getCanvasTargetSize()`, local geometry for dock and popups
+- [x] `app.css`: measured viewport vars, `min-height: 0` on the rotated
+      shell, screen-edge safe-area insets, wrapper cap
+- [x] Verify 430 x 714, 375 x 667, 844 x 390, 1440 x 900; dock and font
+      popup at 430 x 714
+- [x] Update `docs_dreamboard/project/frontend/frontend-docs.md`
+- [x] Run `pnpm run preflight`
+- [ ] Open the PR and check the stage preview on the iPhone 15 Pro Max

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -8,6 +8,7 @@ import {
 } from "./draft-store.js";
 
 const MOBILE_BREAKPOINT = 900;
+const MOBILE_CANVAS_MIN_SIZE = 120;
 const DRAFT_SCHEMA_VERSION = 1;
 const DRAFT_SAVE_DEBOUNCE_MS = 500;
 const EDITOR_ROUTE_HASH = "#editor";
@@ -149,7 +150,25 @@ function dismissRotateHint() {
   syncRotateHintVisibility();
 }
 
+// The phone editor shell is sized in CSS from these two custom properties
+// instead of `dvh` / `dvw`. `innerWidth` / `innerHeight` are the visible
+// layout viewport in every mobile browser, while `100dvh` can exceed the
+// visible height in in-app browsers, which put the far edge of the canvas
+// under the toolbar with no way to scroll to it. The rotated portrait shell
+// also reads them to size and translate its box.
+function updateEditorViewportVars() {
+  document.documentElement.style.setProperty(
+    "--editor-vw",
+    `${window.innerWidth}px`,
+  );
+  document.documentElement.style.setProperty(
+    "--editor-vh",
+    `${window.innerHeight}px`,
+  );
+}
+
 function syncEditorViewport({ dismissForLandscape = false } = {}) {
+  updateEditorViewportVars();
   syncRotateHintVisibility({ dismissForLandscape });
 
   if (editorView.style.display !== "block") {
@@ -518,76 +537,64 @@ function hideFontPopup() {
   fontPopup.style.display = "none";
 }
 
-function positionColorPopup() {
-  if (colorPopup.style.display !== "block") return;
+// Layout geometry inside `.canvas-wrapper`. The wrapper is the offset parent
+// of the object menu and both popups, and the Fabric canvas sits at its
+// origin, so offset values and the canvas size describe the same plane the
+// menu is positioned in. Client rects would not: the rotated portrait shell
+// turns the whole wrapper a quarter, and its screen-space width and height
+// swap places.
+function getLocalCanvasSize() {
+  return { width: canvas.getWidth(), height: canvas.getHeight() };
+}
 
-  const canvasRect = canvas.upperCanvasEl.getBoundingClientRect();
-  const menuRect = objectMenu.getBoundingClientRect();
-  const popupRect = colorPopup.getBoundingClientRect();
+function getLocalRect(element) {
+  return {
+    left: element.offsetLeft,
+    top: element.offsetTop,
+    width: element.offsetWidth,
+    height: element.offsetHeight,
+  };
+}
 
-  const menuTop = menuRect.top - canvasRect.top;
+function positionAnchoredPopup(popup, anchorButton) {
+  if (popup.style.display !== "block") return;
 
-  const spaceAbove = menuRect.top - canvasRect.top;
-  const spaceBelow =
-    canvasRect.top + canvasRect.height - (menuRect.top + menuRect.height);
+  const canvasSize = getLocalCanvasSize();
+  const menuRect = getLocalRect(objectMenu);
+  const popupRect = getLocalRect(popup);
+  const buttonRect = getLocalRect(anchorButton);
+
+  const spaceAbove = menuRect.top;
+  const spaceBelow = canvasSize.height - (menuRect.top + menuRect.height);
 
   let top;
   if (spaceBelow >= popupRect.height + 10 || spaceBelow >= spaceAbove) {
-    top = menuTop + menuRect.height + 10;
+    top = menuRect.top + menuRect.height + 10;
   } else {
-    top = menuTop - popupRect.height - 10;
+    top = menuRect.top - popupRect.height - 10;
   }
 
-  const btnRect = omColorBtn.getBoundingClientRect();
-  const btnCenterX = (btnRect.left + btnRect.right) / 2;
-  let left = btnCenterX - canvasRect.left - popupRect.width / 2;
+  const buttonCenterX = menuRect.left + buttonRect.left + buttonRect.width / 2;
+  let left = buttonCenterX - popupRect.width / 2;
 
   const minLeft = 10;
-  const maxLeft = canvasRect.width - popupRect.width - 10;
+  const maxLeft = canvasSize.width - popupRect.width - 10;
   left = Math.max(minLeft, Math.min(maxLeft, left));
 
   const minTop = 10;
-  const maxTop = canvasRect.height - popupRect.height - 10;
+  const maxTop = canvasSize.height - popupRect.height - 10;
   top = Math.max(minTop, Math.min(maxTop, top));
 
-  colorPopup.style.left = left + "px";
-  colorPopup.style.top = top + "px";
+  popup.style.left = `${left}px`;
+  popup.style.top = `${top}px`;
+}
+
+function positionColorPopup() {
+  positionAnchoredPopup(colorPopup, omColorBtn);
 }
 
 function positionFontPopup() {
-  if (fontPopup.style.display !== "block") return;
-
-  const canvasRect = canvas.upperCanvasEl.getBoundingClientRect();
-  const menuRect = objectMenu.getBoundingClientRect();
-  const popupRect = fontPopup.getBoundingClientRect();
-
-  const menuTop = menuRect.top - canvasRect.top;
-
-  const spaceAbove = menuRect.top - canvasRect.top;
-  const spaceBelow =
-    canvasRect.top + canvasRect.height - (menuRect.top + menuRect.height);
-
-  let top;
-  if (spaceBelow >= popupRect.height + 10 || spaceBelow >= spaceAbove) {
-    top = menuTop + menuRect.height + 10;
-  } else {
-    top = menuTop - popupRect.height - 10;
-  }
-
-  const btnRect = omFontFamilyBtn.getBoundingClientRect();
-  const btnCenterX = (btnRect.left + btnRect.right) / 2;
-  let left = btnCenterX - canvasRect.left - popupRect.width / 2;
-
-  const minLeft = 10;
-  const maxLeft = canvasRect.width - popupRect.width - 10;
-  left = Math.max(minLeft, Math.min(maxLeft, left));
-
-  const minTop = 10;
-  const maxTop = canvasRect.height - popupRect.height - 10;
-  top = Math.max(minTop, Math.min(maxTop, top));
-
-  fontPopup.style.left = left + "px";
-  fontPopup.style.top = top + "px";
+  positionAnchoredPopup(fontPopup, omFontFamilyBtn);
 }
 
 function toggleColorPopup() {
@@ -1169,20 +1176,18 @@ function positionObjectMenu() {
     return;
   }
 
-  const canvasRect = canvas.upperCanvasEl.getBoundingClientRect();
-
   objectMenu.style.left = "0px";
   objectMenu.style.top = "0px";
   objectMenu.style.maxWidth = "";
-  const menuRect = objectMenu.getBoundingClientRect();
 
   if (isMobileLayout()) {
-    const maxDockWidth = Math.max(220, Math.min(canvasRect.width - 20, 360));
+    const canvasSize = getLocalCanvasSize();
+    const maxDockWidth = Math.max(220, Math.min(canvasSize.width - 20, 360));
     objectMenu.style.maxWidth = `${maxDockWidth}px`;
 
-    const dockRect = objectMenu.getBoundingClientRect();
-    const dockLeft = Math.max(10, (canvasRect.width - dockRect.width) / 2);
-    const dockTop = Math.max(10, canvasRect.height - dockRect.height - 12);
+    const dockRect = getLocalRect(objectMenu);
+    const dockLeft = Math.max(10, (canvasSize.width - dockRect.width) / 2);
+    const dockTop = Math.max(10, canvasSize.height - dockRect.height - 12);
 
     objectMenu.style.left = `${dockLeft}px`;
     objectMenu.style.top = `${dockTop}px`;
@@ -1192,6 +1197,8 @@ function positionObjectMenu() {
     return;
   }
 
+  const canvasRect = canvas.upperCanvasEl.getBoundingClientRect();
+  const menuRect = objectMenu.getBoundingClientRect();
   const rect = obj.getBoundingRect(true, true);
   const left = canvasRect.left + rect.left;
   const top = canvasRect.top + rect.top;
@@ -1499,15 +1506,24 @@ function getCanvasTargetSize() {
     };
   }
 
+  const availableWidth = Math.floor(areaWidth - horizontal);
+  const availableHeight = Math.floor(areaHeight - vertical);
+
+  // The phone canvas owns every touch (`touch-action: none`), so nothing that
+  // does not fit the column can be scrolled into view: it always takes the
+  // measured column and only a degenerate measurement is floored.
+  if (isMobileLayout()) {
+    return {
+      width: Math.max(MOBILE_CANVAS_MIN_SIZE, availableWidth),
+      height: Math.max(MOBILE_CANVAS_MIN_SIZE, availableHeight),
+    };
+  }
+
+  // Desktop keeps a working minimum; `.canvas-stage` scrolls when the window
+  // is shorter than it.
   return {
-    width: Math.max(
-      isMobileLayout() ? 280 : 420,
-      Math.floor(areaWidth - horizontal),
-    ),
-    height: Math.max(
-      isMobileLayout() ? 360 : 520,
-      Math.floor(areaHeight - vertical),
-    ),
+    width: Math.max(420, availableWidth),
+    height: Math.max(520, availableHeight),
   };
 }
 
@@ -1573,6 +1589,7 @@ window.addEventListener("pagehide", () => {
 
 // init
 updateLandingViewportVars();
+updateEditorViewportVars();
 syncRotateHintVisibility();
 setLandingPhotos();
 initHeroMountains(document.querySelectorAll(".landing-section.bg-hero"));

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1152,7 +1152,12 @@ body.is-editor-restoring .object-menu {
     0 2px 6px rgba(0, 0, 0, 0.12);
   padding: 8px;
   display: none;
-  max-height: 320px;
+  box-sizing: border-box;
+  /* Never taller than the canvas it is positioned in (`.canvas-wrapper` is
+     the containing block) minus the 10px margins the positioner keeps: on a
+     360px-wide phone the fitted canvas is 332px tall, and a clipped list
+     could not scroll its last fonts into view. */
+  max-height: min(320px, calc(100% - 20px));
   overflow: auto;
   min-width: 220px;
   color: #000 !important;
@@ -1642,11 +1647,11 @@ body.is-editor-active .app-container {
 
   /* Safe-area insets follow the screen, not the rotated box: the screen top
      inset lands on the rail's left edge and the screen bottom inset on the
-     canvas column's right edge. The rail widens by the inset so its tools
-     keep their room. */
+     canvas column's right edge. The rail is content-box, so the padding alone
+     widens it by the inset and the tools keep their 158px. */
   body.is-editor-active .sidebar {
-    width: calc(min(158px, 42vw) + env(safe-area-inset-top));
-    flex: 0 0 calc(min(158px, 42vw) + env(safe-area-inset-top));
+    width: min(158px, 42vw);
+    flex: 0 0 min(158px, 42vw);
     padding: 10px 10px 10px calc(10px + env(safe-area-inset-top));
     gap: 10px;
     overflow: hidden;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1547,9 +1547,14 @@ body.is-editor-active .app-container {
   }
 }
 
+/* The phone editor is sized from the viewport JS measured (`--editor-vw` /
+   `--editor-vh`, set from `innerWidth` / `innerHeight`) rather than from
+   `dvh`: in-app browsers and Safari with a collapsible toolbar report a `dvh`
+   that can exceed the visible height, and a canvas sized to it runs under the
+   toolbar with no way to scroll to it because the canvas owns every touch. */
 @media (max-width: 900px) {
   body.is-editor-active .app-container {
-    height: 100dvh;
+    height: var(--editor-vh, 100dvh);
     flex-direction: row;
   }
 
@@ -1560,7 +1565,7 @@ body.is-editor-active .app-container {
     bottom: auto;
     width: min(220px, 42vw);
     flex: 0 0 min(220px, 42vw);
-    max-height: 100dvh;
+    max-height: var(--editor-vh, 100dvh);
     transform: none;
     border-radius: 0;
     border: none;
@@ -1586,7 +1591,8 @@ body.is-editor-active .app-container {
     width: auto;
     max-width: 100%;
     max-height: calc(
-      100dvh - 28px - env(safe-area-inset-top) - env(safe-area-inset-bottom)
+      var(--editor-vh, 100dvh) - 28px - env(safe-area-inset-top) -
+        env(safe-area-inset-bottom)
     );
   }
 
@@ -1604,14 +1610,21 @@ body.is-editor-active .app-container {
     overflow: hidden;
   }
 
+  /* The shell is laid out landscape (viewport height wide, viewport width
+     tall) and turned a quarter clockwise, so its left edge is the screen top
+     and its right edge the screen bottom. `min-height: 0` matters: the base
+     `.editor-view` floor of `100dvh` would otherwise win over the `100dvw`
+     height and make the box square, pushing the far side of the canvas off
+     the left of the screen. */
   body.is-editor-active .editor-view {
     position: fixed;
     top: 0;
     left: 0;
-    width: 100dvh;
-    height: 100dvw;
+    width: var(--editor-vh, 100dvh);
+    height: var(--editor-vw, 100dvw);
+    min-height: 0;
     transform-origin: top left;
-    transform: translateX(100dvw) rotate(90deg);
+    transform: translateX(var(--editor-vw, 100dvw)) rotate(90deg);
     z-index: 100;
   }
 
@@ -1627,13 +1640,26 @@ body.is-editor-active .app-container {
     top: max(14px, calc(env(safe-area-inset-top) + 14px));
   }
 
+  /* Safe-area insets follow the screen, not the rotated box: the screen top
+     inset lands on the rail's left edge and the screen bottom inset on the
+     canvas column's right edge. The rail widens by the inset so its tools
+     keep their room. */
   body.is-editor-active .sidebar {
-    width: min(158px, 42vw);
-    flex: 0 0 min(158px, 42vw);
-    padding: calc(10px + env(safe-area-inset-top)) 10px
-      calc(10px + env(safe-area-inset-bottom));
+    width: calc(min(158px, 42vw) + env(safe-area-inset-top));
+    flex: 0 0 calc(min(158px, 42vw) + env(safe-area-inset-top));
+    padding: 10px 10px 10px calc(10px + env(safe-area-inset-top));
     gap: 10px;
     overflow: hidden;
+  }
+
+  body.is-editor-active .canvas-area {
+    padding: 14px calc(14px + env(safe-area-inset-bottom)) 14px 14px;
+  }
+
+  /* The canvas is measured to the column by `resizeCanvasToViewport`; the
+     cap only guards a stale frame between a viewport change and the resize. */
+  body.is-editor-active .canvas-wrapper {
+    max-height: calc(var(--editor-vw, 100dvw) - 28px);
   }
 
   body.is-editor-active .sidebar .sidebar-header {


### PR DESCRIPTION
## Summary

Reported on an iPhone 15 Pro Max in an in-app Safari view (2026-09-03): the far end of the editor canvas is cut off by the bottom toolbar and cannot be scrolled into view. Feature memory in `specs/024-mobile-canvas-fit-visible-viewport/`.

Four causes on `main`, all fixed here:

- **The rotated portrait shell was a square.** `body.is-editor-active .editor-view` sets `width: 100dvh; height: 100dvw` but inherits `min-height: 100dvh` from the base `.editor-view`. The floor wins, the box is `100dvh` square, and after the quarter turn `100dvh - 100dvw` of the canvas sits off the left of the screen. At 430 x 714 the canvas was 507 x 686 with 270px outside the viewport. Now `min-height: 0`.
- **`dvh` is not the visible height everywhere.** In-app browsers and Safari with a collapsible toolbar can report a `100dvh` taller than the visible area, and the canvas owns every touch (`touch-action: none`), so anything laid out past it can never be scrolled into view. The phone shell is now sized from `--editor-vw` / `--editor-vh`, written by `updateEditorViewportVars()` from `innerWidth` / `innerHeight` at boot and on every `syncEditorViewport` call; `100dvw` / `100dvh` remain as CSS fallbacks.
- **Phone floors above the column.** `getCanvasTargetSize()` floored phones at 280 x 360; the rotated column is `innerWidth - 28` tall, 347px on a 375px phone. The phone canvas now takes the measured column (120px degenerate-measurement floor only); desktop keeps 420 x 520 and the `.canvas-stage` scroll.
- **Dock and popups placed from screen-space rects.** Inside the rotated wrapper `getBoundingClientRect()` swaps width and height, so the mobile dock landed mid-canvas and ran past its right edge. `positionObjectMenu()` (mobile branch) and the two popup positioners, folded into one `positionAnchoredPopup()`, now read local wrapper geometry (`canvas.getWidth()` / `getHeight()`, `offsetLeft` / `offsetTop` / `offsetWidth` / `offsetHeight`), which the dock drag already used.

Also: in the rotated shell the safe-area insets now follow the screen (screen-top inset on the rail's left edge, screen-bottom inset on the canvas column's right edge) instead of the box's top and bottom, which are the screen's right and left there. `frontend-docs.md` updated (responsive behavior, mobile editor model).

## Validation

- `pnpm run preflight` green (feature memory, baseline, html-validate, build, prettier, 27 tests)
- Browser, 430 x 714 (`#editor`, rotated rail): `.editor-view` rect equals the viewport, `min-height` computes `0px`, canvas 507 x 402 inside `[14, 416] x [193, 700]`; with a text selected the dock lies along the far edge of the canvas, centred, and the font popup opens inside the canvas rect
- Browser, 375 x 667: canvas 461 x 347 inside the viewport (the old 360 floor overflowed by 13px)
- Browser, 844 x 390: canvas 567 x 362 inside the viewport
- Browser, 1440 x 900: canvas 1029 x 835, bottom at the footer top, unchanged from `main`
- `--editor-vw` / `--editor-vh` equal `innerWidth` / `innerHeight` after boot and after a `resize` event

## On-device check (stage preview, iPhone 15 Pro Max)

1. Open the editor in portrait: all nine placeholder labels and the rounded far edge of the canvas are visible above the browser toolbar.
2. Add a text: the object menu lies along the far edge of the canvas; the font picker opens on the canvas.
3. Turn the phone to landscape: the canvas fits between the rail and the screen edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
